### PR TITLE
support mesh / result modes - few scenarios were not working earlier.

### DIFF
--- a/src/ansys/mechanical/core/launcher.py
+++ b/src/ansys/mechanical/core/launcher.py
@@ -50,8 +50,10 @@ class MechanicalLauncher:
             self.__batch_arg_list.append("-AppModeMech")
 
     def _mode_exists(self, mode):
-        if mode.upper() in (mode_temp.upper() for mode_temp in self.additional_args):
-            return True
+        if self.additional_args is not None and isinstance(self.additional_args, list):
+            if mode.upper() in (mode_temp.upper() for mode_temp in self.additional_args):
+                return True
+
         return False
 
     def launch(self):


### PR DESCRIPTION
support mesh / result modes.
By default we use -AppModeMech.
if additional_switches contain '-AppModeMesh' or '-AppModeRest'. We'll respect that. Earlier fix broke the -AppModeMech scenarios.