### PR TITLE
Standardizing data paths

### DIFF
--- a/src/ansys/mechanical/core/__init__.py
+++ b/src/ansys/mechanical/core/__init__.py
@@ -4,6 +4,15 @@ import os
 
 import appdirs
 
+# Setup data directory
+USER_DATA_PATH = appdirs.user_data_dir(appname="ansys_mechanical_core", appauthor="Ansys")
+if not os.path.exists(USER_DATA_PATH):
+    os.makedirs(USER_DATA_PATH)
+
+EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
+if not os.path.exists(EXAMPLES_PATH):
+    os.makedirs(EXAMPLES_PATH)
+
 from ansys.mechanical.core.logging import Logger
 
 # Create logger for package level use
@@ -35,16 +44,3 @@ LOCAL_PORTS = []
 from ansys.mechanical.core.pool import LocalMechanicalPool
 
 BUILDING_GALLERY = False
-
-# Setup data directory
-try:
-    USER_DATA_PATH = appdirs.user_data_dir("ansys_mechanical_core")
-    if not os.path.exists(USER_DATA_PATH):
-        os.makedirs(USER_DATA_PATH)
-
-    EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
-    if not os.path.exists(EXAMPLES_PATH):
-        os.makedirs(EXAMPLES_PATH)
-
-except Exception:
-    pass

--- a/src/ansys/mechanical/core/mechanical.py
+++ b/src/ansys/mechanical/core/mechanical.py
@@ -18,7 +18,6 @@ import ansys.api.mechanical.v0.mechanical_pb2 as mechanical_pb2
 import ansys.api.mechanical.v0.mechanical_pb2_grpc as mechanical_pb2_grpc
 import ansys.platform.instancemanagement as pypim
 from ansys.platform.instancemanagement import Instance
-import appdirs
 import grpc
 
 import ansys.mechanical.core as pymechanical
@@ -93,7 +92,7 @@ def suppress_logging(func):
     return wrapper
 
 
-SETTINGS_DIR = appdirs.user_data_dir("ansys_mechanical_core")
+SETTINGS_DIR = pymechanical.USER_DATA_PATH
 LOG.info(f"ansys_mechanical_core settings directory: {SETTINGS_DIR}")
 
 if not os.path.isdir(SETTINGS_DIR):


### PR DESCRIPTION
Exact same changes as in https://github.com/ansys/pymapdl/pull/2064

Original issue tracker https://github.com/ansys/pyfluent/issues/1588

Changes Windows data path to `%LocalAppData%\Ansys\ansys_mechanical_core`, same naming scheme as in https://github.com/ansys/pyfluent/pull/1615, https://github.com/ansys/pymapdl/pull/2064, https://github.com/ansys/pyprimemesh/pull/485, https://github.com/ansys/ansys-tools-path/pull/44, https://github.com/ansys/pysystem-coupling/pull/158

Changed `SETTINGS_DIR` to point to `USER_DATA_PATH` to make sure these two are always the same and avoid unnecessary `appdirs` use

Removed try-except block

Behavior not changed in this PR: data path/settings dir and examples folders are immediately created on `import ansys.mechnical.core`, might be worth changing to create folders only when/if they are actually used