### PR TITLE
Add version configuration for embedding tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Added
 
+-   Add version configuration for embedding tests (#270)
+
+## [0.9.0](https://github.com/ansys/pymechanical/releases/tag/v0.8.0) - June 13 2023
+
+### Added
+
+-   link to pymechanical remote sessions examples (#252)
+-   add doc to run script without embedding (#262)
+-   pre-commit autoupdate (#269)
+
+### Changed
+
+-   Bump ansys-sphinx-theme from 0.9.8 to 0.9.9 (#248)
+-   Bump grpcio from 1.54.0 to 1.54.2 (#249)
+-   Bump sphinx from 6.2.0 to 6.2.1 (#250)
+-   change image tag in ci/cd (#254)
+-   Bump pyvista from 0.39.0 to 0.39.1 (#256)
+-   Standardizing data paths (#257)
+-   Bump imageio from 2.28.1 to 2.30.0 (#258)
+-   Bump pytest-cov from 4.0.0 to 4.1.0 (#259)
+-   Bump imageio from 2.30.0 to 2.31.0 (#264)
+-   Bump pytest from 7.3.1 to 7.3.2 (#267)
+-   Bump plotly from 5.14.1 to 5.15.0 (#268)
+
+### Fixed
+
+-   FIX: GitHub organization rename to Ansys (#251)
+-   fix examples links (#253)
+-   fix windows pythonnet warning unit tests (#260)
+
+## [0.8.0](https://github.com/ansys/pymechanical/releases/tag/v0.8.0) - May 12 2023
+
+### Added
+
 -   changelog (#222)
 -   add link to embedding examples (#228)
 -   Add `close()` method to `Ansys.Mechanical.Embedding.Application`. See (#229)
@@ -16,25 +50,31 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Changed
 
--   Use ansys-tools-path (#231)
--   Bump sphinx-design from 0.3.0 to 0.4.1 (#219)
--   Bump sphinx-copybutton from 0.5.1 to 0.5.2 (#218)
--   Bump sphinx-gallery from 0.12.2 to 0.13.0 (#217)
--   Bump sphinx-autodoc-typehints from 1.22 to 1.23.0 (#215)
 -   cleanup docker ignore file (#206)
 -   Update contributing.rst (#213)
+-   Bump sphinx-autodoc-typehints from 1.22 to 1.23.0 (#215)
 -   Bump pytest from 7.3.0 to 7.3.1 (#216)
+-   Bump sphinx-gallery from 0.12.2 to 0.13.0 (#217)
+-   Bump sphinx-copybutton from 0.5.1 to 0.5.2 (#218)
+-   Bump sphinx-design from 0.3.0 to 0.4.1 (#219)
 -   Remove python 3.7 (#230)
+-   Use ansys-tools-path (#231)
+-   Bump sphinx from 6.2.0 to 7.0.0 (#232)
+-   Bump imageio from 2.28.0 to 2.28.1 (#233)
+-   ignore generated *.ipynb, *.py, *.rst, *.md5, *.png and *.pickle files (#239)
+-   Bump pyvista from 0.38.5 to 0.39.0 (#245)
 
 ### Fixed
 
--   FIX: GitHub organization rename to Ansys
 -   FIX: not necessary anymore to update apt-get (#220)
 -   Include amd folder for mapdl solver in the docker image. (#200)
 -   Remove jscript references from tests/ folder (#205)
 -   Fixes the windows executable path for standalone mechanical (#214)
 -   FIX: run_python_script* return empty string for objects that cannot be returned as string (#224)
--   call `new()` in the BUILDING_GALLERY constructor of `Ansys.Mechanical.Embedding.Application`. See (#229)
+-   call `new()` in the BUILDING_GALLERY constructor of `Ansys.Mechanical.Embedding.Application` (#229)
+-   fix documentation link (#234)
+-   changed python doc url to fix doc pipeline error (#236)
+-   Docker dependencies to support topo and smart tests (#237)
 
 ## [0.7.3](https://github.com/ansys/pymechanical/releases/tag/v0.7.3) - April 20 2023
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,13 +91,13 @@ def ensure_embedding() -> None:
         raise Exception("Cannot run embedded tests if Mechanical embedding is not installed")
 
 
-def start_embedding_app() -> datetime.timedelta:
+def start_embedding_app(version) -> datetime.timedelta:
     from ansys.mechanical.core import App
 
     global EMBEDDED_APP
     ensure_embedding()
     start = datetime.datetime.now()
-    EMBEDDED_APP = App(version=232)
+    EMBEDDED_APP = App(version=int(version))
     startup_time = (datetime.datetime.now() - start).total_seconds()
     num_cores = os.environ.get("NUM_CORES", None)
     if num_cores != None:
@@ -111,9 +111,9 @@ EMBEDDED_APP = None
 
 
 @pytest.fixture(scope="session")
-def embedded_app(request):
+def embedded_app(pytestconfig, request):
     global EMBEDDED_APP
-    startup_time = start_embedding_app()
+    startup_time = start_embedding_app(pytestconfig.getoption("ansys_version"))
     terminal_reporter = request.config.pluginmanager.getplugin("terminalreporter")
     if terminal_reporter is not None:
         terminal_reporter.write_line(f"\t{startup_time}\tStarting Mechanical")
@@ -292,3 +292,8 @@ def mechanical_pool():
 
     assert f"Mechanical pool with {instances_count} active instances" in str(pool)
     pool.exit(block=True)
+
+
+def pytest_addoption(parser):
+    # parser.addoption("--debugging", action="store_true")
+    parser.addoption("--ansys-version", default="232")

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -6,11 +6,14 @@ import sys
 import pytest
 
 
-def _run_embedding_log_test_process(rootdir, testname) -> subprocess.Popen:
+def _run_embedding_log_test_process(rootdir, pytestconfig, testname) -> subprocess.Popen:
     """Runs the process and returns it after it finishes"""
+    version = pytestconfig.getoption("ansys_version")
     embedded_py = os.path.join(rootdir, "tests", "scripts", "embedding_log_test.py")
     p = subprocess.Popen(
-        [sys.executable, embedded_py, testname], stderr=subprocess.PIPE, stdout=subprocess.PIPE
+        [sys.executable, embedded_py, version, testname],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
     )
     p.wait()
     return p
@@ -35,7 +38,9 @@ def _assert_success(process: subprocess.Popen, pass_expected: bool) -> int:
         assert "@@success@@" not in stdout
 
 
-def _run_embedding_log_test(rootdir: str, testname: str, pass_expected: bool = True) -> str:
+def _run_embedding_log_test(
+    rootdir: str, pytestconfig, testname: str, pass_expected: bool = True
+) -> str:
     """Test stderr logging using a subprocess.
 
     Also ensure that the subprocess either passes or fails based on pass_expected
@@ -45,35 +50,39 @@ def _run_embedding_log_test(rootdir: str, testname: str, pass_expected: bool = T
 
     Returns the stderr
     """
-    p = _run_embedding_log_test_process(rootdir, testname)
+    p = _run_embedding_log_test_process(rootdir, pytestconfig, testname)
     stderr = p.stderr.read().decode()
     _assert_success(p, pass_expected)
     return stderr
 
 
 @pytest.mark.embedding
-def test_logging_write_log_before_init(rootdir):
+def test_logging_write_log_before_init(rootdir, pytestconfig):
     """Test that an error is thrown when trying to log before initializing"""
-    stderr = _run_embedding_log_test(rootdir, "log_before_initialize", False)
+    stderr = _run_embedding_log_test(rootdir, pytestconfig, "log_before_initialize", False)
     assert "Can't log to the embedding logger until Mechanical is initialized" in stderr
 
 
 @pytest.mark.embedding
-def test_logging_write_info_after_initialize_with_error_level(rootdir):
+def test_logging_write_info_after_initialize_with_error_level(rootdir, pytestconfig):
     """Test that no output is written when an info is logged when configured at the error level."""
-    stderr = _run_embedding_log_test(rootdir, "log_info_after_initialize_with_error_level")
+    stderr = _run_embedding_log_test(
+        rootdir, pytestconfig, "log_info_after_initialize_with_error_level"
+    )
     assert "0xdeadbeef" not in stderr
 
 
 @pytest.mark.embedding
-def test_logging_write_error_after_initialize_with_info_level(rootdir):
+def test_logging_write_error_after_initialize_with_info_level(rootdir, pytestconfig):
     """Test that output is written when an error is logged when configured at the info level."""
-    stderr = _run_embedding_log_test(rootdir, "log_error_after_initialize_with_info_level")
+    stderr = _run_embedding_log_test(
+        rootdir, pytestconfig, "log_error_after_initialize_with_info_level"
+    )
     assert "Will no one rid me of this turbulent priest?" in stderr
 
 
 @pytest.mark.embedding
-def test_logging_level_before_and_after_initialization(rootdir):
+def test_logging_level_before_and_after_initialization(rootdir, pytestconfig):
     """Test logging level API  before and after initialization."""
-    p = _run_embedding_log_test_process(rootdir, "log_check_can_log_message")
+    p = _run_embedding_log_test_process(rootdir, pytestconfig, "log_check_can_log_message")
     _assert_success(p, True)

--- a/tests/scripts/embedding_log_test.py
+++ b/tests/scripts/embedding_log_test.py
@@ -7,26 +7,26 @@ import ansys.mechanical.core as mech
 from ansys.mechanical.core.embedding.logger import Configuration, Logger
 
 
-def log_before_initialize():
+def log_before_initialize(version):
     """Write a log without initializing the embedded instance."""
     Logger.error("message")
 
 
-def log_info_after_initialize_with_error_level():
+def log_info_after_initialize_with_error_level(version):
     """Log at the info level after initializing with the error level."""
     Configuration.configure(level=logging.ERROR, to_stdout=True, base_directory=None)
-    _ = mech.App(version=232)
+    _ = mech.App(version=version)
     Logger.info("0xdeadbeef")
 
 
-def log_error_after_initialize_with_info_level():
+def log_error_after_initialize_with_info_level(version):
     """Log at the info level after initializing with the error level."""
-    _ = mech.App(version=232)
+    _ = mech.App(version=version)
     Configuration.configure(level=logging.INFO, to_stdout=True, base_directory=None)
     Logger.error("Will no one rid me of this turbulent priest?")
 
 
-def log_check_can_log_message():
+def log_check_can_log_message(version):
     """Configure logger before app initialization and check can_log_message."""
     Configuration.configure(level=logging.WARNING, to_stdout=True, base_directory=None)
     assert Logger.can_log_message(logging.DEBUG) is False
@@ -34,7 +34,7 @@ def log_check_can_log_message():
     assert Logger.can_log_message(logging.WARNING) is True
     assert Logger.can_log_message(logging.ERROR) is True
     assert Logger.can_log_message(logging.FATAL) is True
-    _ = mech.App(version=232)
+    _ = mech.App(version=version)
     Configuration.set_log_level(logging.INFO)
     assert Logger.can_log_message(logging.DEBUG) is False
     assert Logger.can_log_message(logging.INFO) is True
@@ -44,12 +44,13 @@ def log_check_can_log_message():
 
 
 if __name__ == "__main__":
-    test_name = sys.argv[1]
+    version = sys.argv[1]
+    test_name = sys.argv[2]
     tests = {
         "log_before_initialize": log_before_initialize,
         "log_info_after_initialize_with_error_level": log_info_after_initialize_with_error_level,
         "log_error_after_initialize_with_info_level": log_error_after_initialize_with_info_level,
         "log_check_can_log_message": log_check_can_log_message,
     }
-    tests[test_name]()
+    tests[test_name](int(version))
     print("@@success@@")


### PR DESCRIPTION
By default, pytest will run embedding tests using 2023R2

This allows a new command line argument to specify the version

pytest --ansys-version 241

to request a specific version.

In the future, we can mark specific tests as disabled for specific versions, once we add features that only work in newer versions. That's not done in this branch