### PR TITLE
Use updated ansys-tools-path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 -   Add version configuration for embedding tests (#270)
 
-## [0.9.0](https://github.com/ansys/pymechanical/releases/tag/v0.8.0) - June 13 2023
+### Fixed
+
+-   FIX: Use updated ansys-tools-path to resolve - missing 1 required positional argument: 'exe_loc' issue (#280)
+
+## [0.9.0](https://github.com/ansys/pymechanical/releases/tag/v0.9.0) - June 13 2023
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-mechanical-core"
-version = "0.9.dev0"
+version = "0.9.dev1"
 description = "A python wrapper for Ansys Mechanical"
 readme = "README.rst"
 requires-python = ">=3.7,<4.0"
@@ -31,7 +31,7 @@ classifiers = [
 dependencies = [
     "ansys_api_mechanical==0.1.0",
     "ansys-pythonnet>=3.1.0rc1",
-    "ansys-tools-path>=0.2.3",
+    "ansys-tools-path>=0.2.5",
     "importlib-metadata>=4.0",
     "appdirs>=1.4.0",
     "grpcio>=1.30.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dependencies = [
     "ansys_api_mechanical==0.1.0",
     "ansys-pythonnet>=3.1.0rc1",
-    "ansys-tools-path>=0.2.5",
+    "ansys-tools-path>=0.2.6",
     "importlib-metadata>=4.0",
     "appdirs>=1.4.0",
     "grpcio>=1.30.0",


### PR DESCRIPTION
This resolves the issue - TypeError: is_valid_executable_path() missing 1 required positional argument: 'exe_loc'