### PR TITLE
Added private AppData functionality to embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 ### Added
 
 -   Add version configuration for embedding tests (#270)
+-   Add temporary private AppData functionality to run parallel embedded instances (#279)
 
 ### Fixed
 

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -1,6 +1,7 @@
 """Main application class for embedded Mechanical."""
 import atexit
 import os
+import shutil
 
 from ansys.mechanical.core.embedding import initializer, runtime
 from ansys.mechanical.core.embedding.config import Configuration, configure
@@ -22,14 +23,30 @@ def _dispose_embedded_app(instances):  # pragma: nocover
         instance._dispose()
 
 
+def _cleanup_private_appdata(folder):
+    try:
+        shutil.rmtree(folder)
+    except:
+        for root, dirs, files in os.walk(folder):
+            try:
+                for dir in dirs:
+                    shutil.rmtree(os.path.join(root, dir))
+            except:
+                pass
+
+
 class App:
     """Mechanical embedding Application."""
 
-    def __init__(self, db_file=None, **kwargs):
+    def __init__(self, db_file=None, private_appdata=False, **kwargs):
         """Construct an instance of the mechanical Application.
 
         db_file is an optional path to a mechanical database file (.mechdat or .mechdb)
         you may set a version number with the `version` keyword argument.
+
+        private_appdata is an optional setting for a temporary AppData directory.
+        By default, private_appdata is False. This is beneficial for running parallel
+        instances of mechanical.
         """
         global INSTANCES
         from ansys.mechanical.core import BUILDING_GALLERY
@@ -52,6 +69,12 @@ class App:
 
         configuration = kwargs.get("config", _get_default_configuration())
         configure(configuration)
+
+        if private_appdata:
+            self.pid = os.getpid()
+            self.tmp_dir = initializer.set_private_appdata(self.pid)
+            atexit.register(_cleanup_private_appdata, self.tmp_dir)
+
         self._app = Ansys.Mechanical.Embedding.Application(db_file)
         runtime.initialize(self._version)
         self._disposed = False

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -24,15 +24,7 @@ def _dispose_embedded_app(instances):  # pragma: nocover
 
 
 def _cleanup_private_appdata(folder):
-    try:
-        shutil.rmtree(folder)
-    except:
-        for root, dirs, files in os.walk(folder):
-            try:
-                for dir in dirs:
-                    shutil.rmtree(os.path.join(root, dir))
-            except:
-                pass
+    shutil.rmtree(folder, ignore_errors=True)
 
 
 class App:

--- a/src/ansys/mechanical/core/embedding/initializer.py
+++ b/src/ansys/mechanical/core/embedding/initializer.py
@@ -136,9 +136,9 @@ def set_private_appdata(pid):
     newProfile.set_env()
 
     warnings.warn(
-        "Please be advised that using the private_appdata option allows you to run "
-        "multiple pymechanical instances in parallel, but there are leftover files "
-        r"in a temporary directory:   C:\Users\<username><pid>.",
+        "Using the private_appdata option creates temporary directories when "
+        "running the pymechanical instances in parallel. "
+        f"There may be leftover files in {profileName}.",
         stacklevel=2,
     )
 

--- a/src/ansys/mechanical/core/embedding/initializer.py
+++ b/src/ansys/mechanical/core/embedding/initializer.py
@@ -2,6 +2,7 @@
 from importlib.metadata import distribution
 import os
 from pathlib import Path
+import shutil
 import sys
 import warnings
 
@@ -12,6 +13,56 @@ from ansys.mechanical.core.embedding.resolver import resolve
 
 INITIALIZED_VERSION = None
 SUPPORTED_MECHANICAL_EMBEDDING_VERSIONS_WINDOWS = {241: "2024R1", 232: "2023R2", 231: "2023R1"}
+
+
+class TmpUser:
+    """Create Unique User Profile (for AppData)."""
+
+    def __init__(self, defaultProfile, profileName):
+        """Initialize TmpUser class."""
+        self.defaultProfile = defaultProfile
+        self.profileName = profileName
+
+    def set_env(self):
+        """Set environment variables for new user profile."""
+        home = self.profileName
+        if "win" in sys.platform:
+            os.environ["USERPROFILE"] = home
+            os.environ["APPDATA"] = os.path.join(home, "AppData/Roaming")
+            os.environ["LOCALAPPDATA"] = os.path.join(home, "AppData/Local")
+            os.environ["TMP"] = os.path.join(home, "AppData/Local/Temp")
+            os.environ["TEMP"] = os.path.join(home, "AppData/Local/Temp")
+        elif "lin" in sys.platform:
+            os.environ["HOME"] = home
+
+    def exists(self):
+        """Check if unique profile name already exists."""
+        if os.path.exists(self.profileName):
+            return True
+        else:
+            return False
+
+    def mkdirs(self):
+        """Create unique user profile & set up directory tree."""
+        os.makedirs(self.profileName)
+        if "win" in sys.platform:
+            locs = ["AppData/Roaming", "AppData/Local", "AppData/Local/Temp", "Documents"]
+        elif "lin" in sys.platform:
+            locs = [".config", "temp/reports"]
+
+        for loc in locs:
+            os.makedirs(os.path.join(self.profileName, loc))
+
+    def copy_profiles(self):
+        """Copy directories from current user into new user profile."""
+        if "win" in sys.platform:
+            locs = ["AppData/Roaming/Ansys", "AppData/Local/Ansys"]
+        elif "lin" in sys.platform:
+            locs = [".mw/Application Data/Ansys", ".config/Ansys"]
+        for loc in locs:
+            shutil.copytree(
+                os.path.join(self.defaultProfile, loc), os.path.join(self.profileName, loc)
+            )
 
 
 def __add_sys_path(version) -> str:
@@ -66,6 +117,32 @@ def _get_default_version() -> int:
     # version is of the form 23.2
     int_version = int(str(version).replace(".", ""))
     return int_version
+
+
+def set_private_appdata(pid):
+    """Set up unique user sessions when running parallel instances."""
+    defaultProfile = os.path.expanduser("~")
+    profileName = rf"{os.path.expanduser( '~' )}{pid}"
+
+    newProfile = TmpUser(defaultProfile, profileName)
+
+    if newProfile.exists():
+        newProfile.delete_dir()
+
+    newProfile.mkdirs()
+
+    newProfile.copy_profiles()
+
+    newProfile.set_env()
+
+    warnings.warn(
+        "Please be advised that using the private_appdata option allows you to run "
+        "multiple pymechanical instances in parallel, but there are leftover files "
+        r"in a temporary directory:   C:\Users\<username><pid>.",
+        stacklevel=2,
+    )
+
+    return profileName
 
 
 def initialize(version=None):

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -103,21 +103,13 @@ def test_private_appdata(test_env, rootdir):
     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
 
     # Set ShowTriad to False
-    set_showtriad = subprocess.Popen(
-        [test_env.python, embedded_py, "True", "Set"],
-        stdout=subprocess.PIPE,
-        env=test_env.env,
-    )
-    set_showtriad.wait()
+    subprocess.check_call([test_env.python, embedded_py, "True", "Set"], env=test_env.env)
 
     # Check ShowTriad is True for private_appdata embedded sessions
-    launch_private_app = subprocess.Popen(
-        [test_env.python, embedded_py, "True", "Run"],
-        stdout=subprocess.PIPE,
-        env=test_env.env,
+    stdout = subprocess.check_output(
+        [test_env.python, embedded_py, "True", "Run"], env=test_env.env
     )
-    launch_private_app.wait()
-    stdout = launch_private_app.stdout.read().decode().strip("\n").strip("\r")
+    stdout = stdout.decode().strip("\r\n")
 
     assert stdout == "True"
 
@@ -137,29 +129,16 @@ def test_normal_appdata(test_env, rootdir):
     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
 
     # Set ShowTriad to False
-    set_showtriad = subprocess.Popen(
-        [test_env.python, embedded_py, "False", "Set"],
-        stdout=subprocess.PIPE,
-        env=test_env.env,
-    )
-    set_showtriad.wait()
+    subprocess.check_call([test_env.python, embedded_py, "False", "Set"], env=test_env.env)
 
     # Check ShowTriad is False for regular embedded session
-    launch_app = subprocess.Popen(
-        [test_env.python, embedded_py, "False", "Run"],
-        stdout=subprocess.PIPE,
-        env=test_env.env,
+    stdout = subprocess.check_output(
+        [test_env.python, embedded_py, "False", "Run"], env=test_env.env
     )
-    launch_app.wait()
-    stdout = launch_app.stdout.read().decode().strip("\n").strip("\r")
+    stdout = stdout.decode().strip("\r\n")
 
     # Set ShowTriad back to True for regular embedded session
-    reset_showtriad = subprocess.Popen(
-        [test_env.python, embedded_py, "False", "Reset"],
-        stdout=subprocess.PIPE,
-        env=test_env.env,
-    )
-    reset_showtriad.wait()
+    subprocess.check_call([test_env.python, embedded_py, "False", "Reset"], env=test_env.env)
 
     # Assert ShowTriad was set to False for regular embedded session
     assert stdout == "False"

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -86,3 +86,80 @@ def test_warning_message(test_env, rootdir):
 
     # Assert warning message appears for embedded app
     assert warning, "UserWarning should appear in the output of the script"
+
+
+@pytest.mark.embedding
+@pytest.mark.python_env
+def test_private_appdata(test_env, rootdir):
+    """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
+
+    # Install pymechanical
+    subprocess.check_call(
+        [test_env.python, "-m", "pip", "install", "-e", "."],
+        cwd=rootdir,
+        env=test_env.env,
+    )
+
+    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
+
+    # Set ShowTriad to False
+    set_showtriad = subprocess.Popen(
+        [test_env.python, embedded_py, "True", "Set"],
+        stdout=subprocess.PIPE,
+        env=test_env.env,
+    )
+    set_showtriad.wait()
+
+    # Check ShowTriad is True for private_appdata embedded sessions
+    launch_private_app = subprocess.Popen(
+        [test_env.python, embedded_py, "True", "Run"],
+        stdout=subprocess.PIPE,
+        env=test_env.env,
+    )
+    launch_private_app.wait()
+    stdout = launch_private_app.stdout.read().decode().strip("\n").strip("\r")
+
+    assert stdout == "True"
+
+
+@pytest.mark.embedding
+@pytest.mark.python_env
+def test_normal_appdata(test_env, rootdir):
+    """Test embedded instance saves ShowTriad value using a test-scoped Python environment."""
+
+    # Install pymechanical
+    subprocess.check_call(
+        [test_env.python, "-m", "pip", "install", "-e", "."],
+        cwd=rootdir,
+        env=test_env.env,
+    )
+
+    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
+
+    # Set ShowTriad to False
+    set_showtriad = subprocess.Popen(
+        [test_env.python, embedded_py, "False", "Set"],
+        stdout=subprocess.PIPE,
+        env=test_env.env,
+    )
+    set_showtriad.wait()
+
+    # Check ShowTriad is False for regular embedded session
+    launch_app = subprocess.Popen(
+        [test_env.python, embedded_py, "False", "Run"],
+        stdout=subprocess.PIPE,
+        env=test_env.env,
+    )
+    launch_app.wait()
+    stdout = launch_app.stdout.read().decode().strip("\n").strip("\r")
+
+    # Set ShowTriad back to True for regular embedded session
+    reset_showtriad = subprocess.Popen(
+        [test_env.python, embedded_py, "False", "Reset"],
+        stdout=subprocess.PIPE,
+        env=test_env.env,
+    )
+    reset_showtriad.wait()
+
+    # Assert ShowTriad was set to False for regular embedded session
+    assert stdout == "False"

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -1,5 +1,46 @@
 """Launch embedded instance."""
 import ansys.mechanical.core as pymechanical
 
-# Launch embedded instance of app
-app = pymechanical.App()
+
+def launch_app(appdata_option):
+    """Launch embedded instance of app."""
+    if appdata_option == "True":
+        app = pymechanical.App(private_appdata=appdata_option)
+    else:
+        app = pymechanical.App()
+    return app
+
+
+def set_false(appdata_option):
+    """Launch embedded instance of app & set ShowTriad to False."""
+    app = launch_app(appdata_option)
+    app.ExtAPI.Graphics.ViewOptions.ShowTriad = False
+    app.close()
+
+
+def check_showtriad(appdata_option):
+    """Return ShowTriad value."""
+    app = launch_app(appdata_option)
+    print(app.ExtAPI.Graphics.ViewOptions.ShowTriad)
+    app.close()
+
+
+def reset_showtriad(appdata_option):
+    """Set ShowTriad value to True for user."""
+    app = launch_app(appdata_option)
+    app.ExtAPI.Graphics.ViewOptions.ShowTriad = True
+    app.close()
+
+
+try:
+    appdata_option = sys.argv[1]
+    action = sys.argv[2]
+
+    if action == "Set":
+        set_false(appdata_option)
+    elif action == "Run":
+        check_showtriad(appdata_option)
+    elif action == "Reset":
+        reset_showtriad(appdata_option)
+except:
+    launch_app("")

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -1,4 +1,6 @@
 """Launch embedded instance."""
+import sys
+
 import ansys.mechanical.core as pymechanical
 
 

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -13,24 +13,17 @@ def launch_app(appdata_option):
     return app
 
 
-def set_false(appdata_option):
+def set_showtriad(appdata_option, value):
     """Launch embedded instance of app & set ShowTriad to False."""
     app = launch_app(appdata_option)
-    app.ExtAPI.Graphics.ViewOptions.ShowTriad = False
+    app.ExtAPI.Graphics.ViewOptions.ShowTriad = value
     app.close()
 
 
-def check_showtriad(appdata_option):
+def print_showtriad(appdata_option):
     """Return ShowTriad value."""
     app = launch_app(appdata_option)
     print(app.ExtAPI.Graphics.ViewOptions.ShowTriad)
-    app.close()
-
-
-def reset_showtriad(appdata_option):
-    """Set ShowTriad value to True for user."""
-    app = launch_app(appdata_option)
-    app.ExtAPI.Graphics.ViewOptions.ShowTriad = True
     app.close()
 
 
@@ -39,10 +32,10 @@ try:
     action = sys.argv[2]
 
     if action == "Set":
-        set_false(appdata_option)
+        set_showtriad(appdata_option, False)
     elif action == "Run":
-        check_showtriad(appdata_option)
+        print_showtriad(appdata_option)
     elif action == "Reset":
-        reset_showtriad(appdata_option)
+        set_showtriad(appdata_option, True)
 except:
     launch_app("")


### PR DESCRIPTION
Created temporary user directories to allow for multiple instances of embedding to run in parallel. By default, private_appdata is False, meaning it will not create temporary user profiles when running an embedded instance. Since the temporary user directories are not fully removed at exit due to lingering licensing processes, I thought it would make sense to default private_appdata to False unless people want to run parallelly. I will be creating another issue to address fully removing the temporary directories. 

This PR relates to #279.