### PR TITLE
remove pkg-resources and importlib_metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,18 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Added
 
--   Add console script (#297)
--   added import logging to doc file (#299)
+-   Add ansys-mechanical console script (#297)
 
 ### Changed
 
 -   Bump matplotlib from 3.7.1 to 3.7.2 (#294)
 -   Bump pyvista from 0.40.0 to 0.40.1 (#293)
+-   remove pkg-resources and importlib_metadata #300
 
 ### Fixed
 
 -   Update code snippet for accessing project directory. (#295)
+-   added import logging to doc file (#299)
 
 ## [0.9.2](https://github.com/ansys/pymechanical/releases/tag/v0.9.1) - July 7 2023
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "appdirs>=1.4.0",
     "click>=8.1.3", # for CLI interface
     "grpcio>=1.30.0",
-    "importlib-metadata>=4.0",
     "protobuf>=3.12.2,<3.21.0",
     "tqdm>=4.45.0",
 ]

--- a/src/ansys/mechanical/core/embedding/loader.py
+++ b/src/ansys/mechanical/core/embedding/loader.py
@@ -1,23 +1,11 @@
 """clr_loader for pymechanical embedding. This loads the CLR on both windows and linux."""
 import os
 
-try:
-    from importlib.metadata import version
-
-    HAS_IMPORTLIB = True
-except:  # pragma: no cover
-    # TODO - only support importlib.metadata::version after dropping python3.7 support.
-    # pkg_resources is part of distutils and is considered obsolete.
-    import pkg_resources
-
-    HAS_IMPORTLIB = False
+from importlib.metadata import version
 
 
 def __get_clr_loader_version():
-    if HAS_IMPORTLIB:
-        return version("clr_loader")
-    else:  # pragma: no cover
-        return pkg_resources.get_distribution("clr_loader").version
+    return version("clr_loader")
 
 
 def __get_mono(assembly_dir, config_dir):


### PR DESCRIPTION
These are not needed now that we don't support python 3.7 anymore.

Fixes #288 