### PR TITLE
Fix version issue running "ansys-mechanical -r {revn} -g"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 -   Update code snippet for accessing project directory. (#295)
 -   added import logging to doc file (#299)
+-   Fix version variable issue running "ansys-mechanical -r {revn} -g" (#302)
 
 ## [0.9.2](https://github.com/ansys/pymechanical/releases/tag/v0.9.1) - July 7 2023
 

--- a/src/ansys/mechanical/core/run.py
+++ b/src/ansys/mechanical/core/run.py
@@ -136,10 +136,10 @@ def cli(
 
     if not revision:
         exe, version = atp.find_mechanical()
-        version = int(version * 10)
     else:
-        exe, _ = atp.find_mechanical(version=revision)
+        exe, version = atp.find_mechanical(version=revision)
 
+    version = int(version * 10)
     version_name = atp.SUPPORTED_ANSYS_VERSIONS[version]
 
     args = [exe, "-DSApplet"]


### PR DESCRIPTION
UnboundLocalError for version variable in run.py when running "ansys-mechanical -r {revn} -g" in the command line.

Closes #301