### PR TITLE
Added warning for ansys-mechanical when provided an input script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Added
 
+-   Added warning for ansys-mechanical when provided an input script (#319)
+
 ### Changed
 
 ### Fixed

--- a/src/ansys/mechanical/core/run.py
+++ b/src/ansys/mechanical/core/run.py
@@ -4,6 +4,7 @@ import asyncio
 from asyncio.subprocess import PIPE
 import os
 import sys
+import warnings
 
 import ansys.tools.path as atp
 import click
@@ -170,6 +171,11 @@ def cli(
     if input_script:
         args.append("-script")
         args.append(input_script)
+        warnings.warn(
+            "Please ensure ExtAPI.Application.Close() is at the end of your script. "
+            "Without this command, Batch mode will not terminate.",
+            stacklevel=2,
+        )
 
     print(f"Starting Ansys Mechanical version {version_name} in {mode} mode...")
     if port:


### PR DESCRIPTION
Added user warning when ansys-mechanical is run with the -i option (input script).