### PR TITLE
Fixed warning message for ansys-mechanical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 ### Added
 
 -   Added warning for ansys-mechanical when provided an input script (#319)
+-   Added version check for ansys-mechanical warning message (#323)
 
 ### Changed
 

--- a/src/ansys/mechanical/core/run.py
+++ b/src/ansys/mechanical/core/run.py
@@ -171,18 +171,13 @@ def cli(
     if input_script:
         args.append("-script")
         args.append(input_script)
+
+    if (not graphical) and input_script and (version < 241):
         warnings.warn(
             "Please ensure ExtAPI.Application.Close() is at the end of your script. "
             "Without this command, Batch mode will not terminate.",
             stacklevel=2,
         )
-
-        if version < 241:
-            warnings.warn(
-                "Please ensure ExtAPI.Application.Close() is at the end of your script. "
-                "Without this command, Batch mode will not terminate.",
-                stacklevel=2,
-            )
 
     print(f"Starting Ansys Mechanical version {version_name} in {mode} mode...")
     if port:

--- a/src/ansys/mechanical/core/run.py
+++ b/src/ansys/mechanical/core/run.py
@@ -171,11 +171,13 @@ def cli(
     if input_script:
         args.append("-script")
         args.append(input_script)
-        warnings.warn(
-            "Please ensure ExtAPI.Application.Close() is at the end of your script. "
-            "Without this command, Batch mode will not terminate.",
-            stacklevel=2,
-        )
+
+        if version < 241:
+            warnings.warn(
+                "Please ensure ExtAPI.Application.Close() is at the end of your script. "
+                "Without this command, Batch mode will not terminate.",
+                stacklevel=2,
+            )
 
     print(f"Starting Ansys Mechanical version {version_name} in {mode} mode...")
     if port:

--- a/src/ansys/mechanical/core/run.py
+++ b/src/ansys/mechanical/core/run.py
@@ -4,6 +4,7 @@ import asyncio
 from asyncio.subprocess import PIPE
 import os
 import sys
+import warnings
 
 import ansys.tools.path as atp
 import click
@@ -170,6 +171,11 @@ def cli(
     if input_script:
         args.append("-script")
         args.append(input_script)
+        warnings.warn(
+            "Please ensure ExtAPI.Application.Close() is at the end of your script. "
+            "Without this command, Batch mode will not terminate.",
+            stacklevel=2,
+        )
 
     print(f"Starting Ansys Mechanical version {version_name} in {mode} mode...")
     if port:


### PR DESCRIPTION
Removed duplicate warning message and adjusted the warning so that it only runs in batch mode with an input script when the revision is under 241.