### PR TITLE
Minor private appdata updates

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        should-release: 
+        should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:
           - should-release: false
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          
+
       - name: Get all doc files that have changed
         id: changed-files-yaml
         uses: tj-actions/changed-files@v37
@@ -168,7 +168,7 @@ jobs:
   embedding-tests:
     name: Embedding testing and coverage
     runs-on: ubuntu-latest
-    # needs: [smoke-tests]
+    needs: [style]
     container:
       image: ghcr.io/ansys/mechanical:23.2.0
       options: --entrypoint /bin/bash
@@ -382,7 +382,7 @@ jobs:
           mv cov-dir/launch/.coverage .coverage.Launch
           mv cov-dir/normal/.coverage .coverage.Normal
           rm -rf cov-dir
-      
+
       - name: Generate .coveragerc file
         run: |
           cat > .coveragerc << 'EOF'
@@ -398,7 +398,7 @@ jobs:
               /usr/local/lib/**/ansys/mechanical
 
           EOF
-      
+
       - name: Run coverage merge and show results
         run: |
           coverage combine --keep --debug=pathmap --rcfile=.coveragerc

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -201,7 +201,7 @@ jobs:
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          /install/ansys_inc/v232/aisol/.workbench_lite pytest -m embedding > pytest_output.txt || true
+          /install/ansys_inc/v232/aisol/.workbench_lite pytest -m embedding -k logging > pytest_output.txt || true
           cat pytest_output.txt
           #
           # Check if failure occurred

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -201,7 +201,7 @@ jobs:
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          /install/ansys_inc/v232/aisol/.workbench_lite pytest -m embedding -k logging > pytest_output.txt || true
+          /install/ansys_inc/v232/aisol/.workbench_lite pytest -m embedding > pytest_output.txt || true
           cat pytest_output.txt
           #
           # Check if failure occurred

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 ### Changed
 
 -   Update python minimum requirement from 3.7 to 3.8 (#333)
+-   Minor private appdata updates (#335)
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ tests = [
     "pytest==7.4.0",
     "pytest-cov==4.1.0",
     "pytest-print==0.3.3",
+    "clr-loader==0.2.6",
 ]
 doc = [
     "Sphinx==7.1.2",

--- a/src/ansys/mechanical/core/embedding/initializer.py
+++ b/src/ansys/mechanical/core/embedding/initializer.py
@@ -122,7 +122,7 @@ def _get_default_version() -> int:
 def set_private_appdata(pid):
     """Set up unique user sessions when running parallel instances."""
     defaultProfile = os.path.expanduser("~")
-    profileName = rf"{os.path.expanduser( '~' )}{pid}"
+    profileName = os.path.join(defaultProfile, f"PyMechanical-{pid}")
 
     newProfile = TmpUser(defaultProfile, profileName)
 

--- a/src/ansys/mechanical/core/embedding/initializer.py
+++ b/src/ansys/mechanical/core/embedding/initializer.py
@@ -138,8 +138,7 @@ def set_private_appdata(pid):
     warnings.warn(
         "Using the private_appdata option creates temporary directories when "
         "running the pymechanical instances in parallel. "
-        f"There may be leftover files in {profileName}.",
-        stacklevel=2,
+        f"There may be leftover files in {profileName}."
     )
 
     return profileName

--- a/src/ansys/mechanical/core/embedding/loader.py
+++ b/src/ansys/mechanical/core/embedding/loader.py
@@ -11,21 +11,13 @@ def __get_mono(assembly_dir, config_dir):
     import clr_loader
 
     libmono = os.path.join(assembly_dir, "libmonosgen-2.0.so")
-    if __get_clr_loader_version() == "0.2.5":
-        mono = clr_loader.get_mono(
-            set_signal_chaining=True,
-            libmono=libmono,
-            assembly_dir=assembly_dir.encode("utf-8"),
-            config_dir=config_dir.encode("utf-8"),
-        )
-    else:
-        # the bugs with get_mono are fixed (clr_loader PR #48)
-        mono = clr_loader.get_mono(
-            set_signal_chaining=True,
-            libmono=libmono,  # find_mono is broken on version 0.2.6
-            assembly_dir=assembly_dir,
-            config_dir=config_dir,
-        )
+    # the bugs with get_mono are fixed (clr_loader PR #48)
+    mono = clr_loader.get_mono(
+        set_signal_chaining=True,
+        libmono=libmono,  # find_mono is broken on version 0.2.6
+        assembly_dir=assembly_dir,
+        config_dir=config_dir,
+    )
     return mono
 
 

--- a/src/ansys/mechanical/core/embedding/loader.py
+++ b/src/ansys/mechanical/core/embedding/loader.py
@@ -10,8 +10,8 @@ def __get_clr_loader_version():
 def __get_mono(assembly_dir, config_dir):
     import clr_loader
 
+    libmono = os.path.join(assembly_dir, "libmonosgen-2.0.so")
     if __get_clr_loader_version() == "0.2.5":
-        libmono = os.path.join(assembly_dir, "libmonosgen-2.0.so")
         mono = clr_loader.get_mono(
             set_signal_chaining=True,
             libmono=libmono,
@@ -21,7 +21,10 @@ def __get_mono(assembly_dir, config_dir):
     else:
         # the bugs with get_mono are fixed (clr_loader PR #48)
         mono = clr_loader.get_mono(
-            set_signal_chaining=True, assembly_dir=assembly_dir, config_dir=config_dir
+            set_signal_chaining=True,
+            libmono=libmono, #find_mono is broken on version 0.2.6
+            assembly_dir=assembly_dir,
+            config_dir=config_dir
         )
     return mono
 

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -27,7 +27,7 @@ def _assert_success(process: subprocess.Popen, pass_expected: bool) -> int:
 
     # HACK! On linux, due to bug #85, there is always a crash on shutdown
     # so instead there's a print("success") that happens after the test
-    # function runs, which will only be execution if the function doesn't
+    # function runs that will only be executed if the function doesn't
     # throw. To check for the subprocess success, ensure that the stdout
     # has "@@success@@" (a value written there in the subprocess after the
     # test function runs)

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -4,38 +4,39 @@ import sys
 import ansys.mechanical.core as pymechanical
 
 
-def launch_app(appdata_option):
+def launch_app(version, private_appdata):
     """Launch embedded instance of app."""
-    if appdata_option == "True":
-        app = pymechanical.App(private_appdata=appdata_option)
-    else:
-        app = pymechanical.App()
+    app = pymechanical.App(version=version, private_appdata=private_appdata)
     return app
 
 
-def set_showtriad(appdata_option, value):
+def set_showtriad(version, appdata_option, value):
     """Launch embedded instance of app & set ShowTriad to False."""
-    app = launch_app(appdata_option)
+    app = launch_app(version, appdata_option)
     app.ExtAPI.Graphics.ViewOptions.ShowTriad = value
     app.close()
 
 
-def print_showtriad(appdata_option):
+def print_showtriad(version, appdata_option):
     """Return ShowTriad value."""
-    app = launch_app(appdata_option)
+    app = launch_app(version, appdata_option)
     print(app.ExtAPI.Graphics.ViewOptions.ShowTriad)
     app.close()
 
 
-try:
-    appdata_option = sys.argv[1]
-    action = sys.argv[2]
+if __name__ == "__main__":
+    version = sys.argv[1]
+    if len(sys.argv) == 2:
+        launch_app(version, False)
+        sys.exit(0)
 
+    appdata_option = sys.argv[2]
+    action = sys.argv[3]
+
+    private_appdata = appdata_option == "True"
     if action == "Set":
-        set_showtriad(appdata_option, False)
+        set_showtriad(version, private_appdata, False)
     elif action == "Run":
-        print_showtriad(appdata_option)
+        print_showtriad(version, private_appdata)
     elif action == "Reset":
-        set_showtriad(appdata_option, True)
-except:
-    launch_app("")
+        set_showtriad(version, private_appdata, True)


### PR DESCRIPTION
Use an easier to find path name
don't give a stack trace for warning
don't use virtual environments for tests
pass version number into tests
don't use exceptions for flow control in test file