### PR TITLE
update clr-loader dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 -   Update python minimum requirement from 3.7 to 3.8 (#333)
 -   Minor private appdata updates (#335)
 -   Bump ansys-sphinx-theme from 0.10.0 to 0.10.2 (#337)
+-   Update clr-loader dependency (#339)
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "ansys-tools-path>=0.3.1",
     "appdirs>=1.4.0",
     "click>=8.1.3", # for CLI interface
+    "clr-loader==0.2.6",
     "grpcio>=1.30.0",
     "protobuf>=3.12.2,<3.21.0",
     "tqdm>=4.45.0",
@@ -51,7 +52,6 @@ tests = [
     "pytest==7.4.0",
     "pytest-cov==4.1.0",
     "pytest-print==0.3.3",
-    "clr-loader==0.2.6",
 ]
 doc = [
     "Sphinx==7.1.2",

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -79,7 +79,7 @@ class App:
             atexit.register(_cleanup_private_appdata, self.tmp_dir)
 
         self._app = _start_application(configuration, self._version, db_file)
-        runtime.initialize(self._version)
+        runtime.initialize()
         self._disposed = False
         atexit.register(_dispose_embedded_app, INSTANCES)
         INSTANCES.append(self)

--- a/src/ansys/mechanical/core/embedding/loader.py
+++ b/src/ansys/mechanical/core/embedding/loader.py
@@ -1,6 +1,7 @@
 """clr_loader for pymechanical embedding. This loads the CLR on both windows and linux."""
 import os
 
+
 def __get_mono(assembly_dir, config_dir):
     import clr_loader
 

--- a/src/ansys/mechanical/core/embedding/loader.py
+++ b/src/ansys/mechanical/core/embedding/loader.py
@@ -1,20 +1,13 @@
 """clr_loader for pymechanical embedding. This loads the CLR on both windows and linux."""
-from importlib.metadata import version
 import os
-
-
-def __get_clr_loader_version():
-    return version("clr_loader")
-
 
 def __get_mono(assembly_dir, config_dir):
     import clr_loader
 
     libmono = os.path.join(assembly_dir, "libmonosgen-2.0.so")
-    # the bugs with get_mono are fixed (clr_loader PR #48)
     mono = clr_loader.get_mono(
         set_signal_chaining=True,
-        libmono=libmono,  # find_mono is broken on version 0.2.6
+        libmono=libmono,  # TODO: find_mono is broken on clr-loader v0.2.6
         assembly_dir=assembly_dir,
         config_dir=config_dir,
     )
@@ -37,10 +30,3 @@ def load_clr(install_loc: str) -> None:
     if os.name == "nt":  # pragma: no cover
         return
     load_clr_mono(install_loc)
-
-
-def is_pythonnet_3() -> bool:
-    """Return whether pythonnet version 3 is used."""
-    import clr
-
-    return 3 == int(clr.__version__.split(".")[0])

--- a/src/ansys/mechanical/core/embedding/runtime.py
+++ b/src/ansys/mechanical/core/embedding/runtime.py
@@ -23,16 +23,4 @@ def initialize(version: int) -> None:
     do some special codec handling to make sure the
     interop works well for Mechanical.
     """
-    if loader.is_pythonnet_3():
-        __initialize_runtime_pythonnet_3()
-    else:  # pragma: no cover
-        # pythonnet 2.5 is supported with some codecs
-        # and some additions to the system path that are shipped with Mechanical in 2023 R1
-        # these additions to the system path may not be desirable for pymechanical embedding
-        if version == 231:
-            import clr
-
-            clr.AddReference("Ansys.Mechanical.CPython")
-            import Ansys
-
-            Ansys.Mechanical.CPython.CPythonEngine.InitializeRuntime()
+    __initialize_runtime_pythonnet_3()

--- a/src/ansys/mechanical/core/embedding/runtime.py
+++ b/src/ansys/mechanical/core/embedding/runtime.py
@@ -1,12 +1,14 @@
 """Runtime initialize for pythonnet in embedding."""
-from ansys.mechanical.core.embedding import loader
 
 
-def __initialize_runtime_pythonnet_3():
-    """Add the codecs that are in python3.
+def initialize() -> None:
+    """Initialize the runtime.
 
-    These are needed for many things, including
-    Mechanical's list conversions (python list to C# lists).
+    Pythonnet is already initialized but we need to
+    do some special codec handling to make sure the
+    interop works well for Mechanical. These are
+    need to handle (among other things) list and other
+    container conversions between C# and python
     """
     import Python.Runtime.Codecs as codecs
 
@@ -14,13 +16,3 @@ def __initialize_runtime_pythonnet_3():
     codecs.SequenceDecoder.Instance.Register()
     codecs.IterableDecoder.Instance.Register()
     # TODO - FunctionCodec
-
-
-def initialize(version: int) -> None:
-    """Initialize the runtime.
-
-    Pythonnet is already initialized but we need to
-    do some special codec handling to make sure the
-    interop works well for Mechanical.
-    """
-    __initialize_runtime_pythonnet_3()


### PR DESCRIPTION
don't support pythonnet 2.x
pin clr-loader for dependencies, not for tests