### PR TITLE
Max parallel 2 for embedding tests - ci_cd.yml

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -173,6 +173,7 @@ jobs:
       image: ghcr.io/ansys/mechanical:23.2.0
       options: --entrypoint /bin/bash
     strategy:
+      max-parallel: 2
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Added
 
+-   Max parallel 2 for embedding tests - ci_cd.yml (#341)
+
 ### Changed
 
-- Remove library-namespace from CI/CD (#342)
+-   Remove library-namespace from CI/CD (#342)
 
 ### Fixed
 


### PR DESCRIPTION
Added "max-parallel: 2" for embedding test runs, since the license server should be able to handle two concurrent runs. This could resolve manually cancelling and re-running embedding tests that are running longer than expected.