### PR TITLE
Fix private appdata issue

### DIFF
--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -76,7 +76,6 @@ class App:
         if private_appdata:
             new_profile_name = f"PyMechanical-{os.getpid()}"
             profile = UniqueUserProfile(new_profile_name)
-            profile.warn()
             profile.update_environment(os.environ)
             atexit.register(_cleanup_private_appdata, profile)
 


### PR DESCRIPTION
Fixes #287 
Change the warning to only happen if a file doesn't get deleted, and print out the name of that file


The file which isn't deleted is referred to using the `TEMP` environment variable on windows. I think it is OK for multiple instances of pymechanical to point to the system temp folder (the issue with parallel instances is related to other parts of the appdata)