### PR TITLE
fix: issues with PyPIM object.inv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Fixed
 
+-   Fix issues with PyPIM object.inv location (#345)
+
 ## [0.10.1](https://github.com/ansys/pymechanical/releases/tag/v0.10.1) - August 8 2023
 
 ### Changed

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -65,7 +65,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/devdocs", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
     "grpc": ("https://grpc.github.io/grpc/python/", None),
-    "pypim": ("https://pypim.docs.pyansys.com/", None),
+    "pypim": ("https://pypim.docs.pyansys.com/version/dev/", None),
 }
 
 suppress_warnings = ["label.*"]


### PR DESCRIPTION
As title says - PyPIM moved to the multiversioning scheme causing some of these links to break