### PR TITLE
Add links for doc and cheat sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Added
 
+-   Add a "Documentation and issues" section to README and doc landing page (#347)
+
+### Added
+
 -   Max parallel 2 for embedding tests - ci_cd.yml (#341)
 -   New features for ansys-mechanical console script (#343)
 

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,8 @@ Install PyMechanical using `pip` with::
 
    pip install ansys-mechanical-core
 
-For more details, see `PyMechanical - Install the package <https://mechanical.docs.pyansys.com/version/stable/getting_started/index.html>`_
+For more information, see `Install the package <https://mechanical.docs.pyansys.com/version/stable/getting_started/index.html>`_
+in the PyMechanical documentation.
 
 
 Dependencies
@@ -109,6 +110,26 @@ and later. Here is an example:
 
    app = pymechanical.App()
    project_dir = app.ExtAPI.DataModel.Project.ProjectDirectory
+
+Documentation and issues
+------------------------
+Documentation for the latest stable release of PyMechanical is hosted at `PyMechanical documentation
+<https://mechanical.docs.pyansys.com/version/stable/>`_.
+
+In the upper right corner of the documentation's title bar, there is an option for switching from
+viewing the documentation for the latest stable release to viewing the documentation for the
+development version or previously released versions.
+
+You can also `view <https://cheatsheets.docs.pyansys.com/pymechanical_cheat_sheet.png>`_ or
+`download <https://cheatsheets.docs.pyansys.com/pymechanical_cheat_sheet.pdf>`_ the
+PyMechanical cheat sheet. This one-page reference provides syntax rules and commands
+for using PyMechanical. 
+
+On the `PyMechanical Issues <https://github.com/ansys/pymechanical/issues>`_ page,
+you can create issues to submit questions, report bugs, and request new features.
+This is the best place to post questions and code.
+
+To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 Testing and Development
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -123,11 +123,12 @@ development version or previously released versions.
 You can also `view <https://cheatsheets.docs.pyansys.com/pymechanical_cheat_sheet.png>`_ or
 `download <https://cheatsheets.docs.pyansys.com/pymechanical_cheat_sheet.pdf>`_ the
 PyMechanical cheat sheet. This one-page reference provides syntax rules and commands
-for using PyMechanical. 
+for using PyMechanical.
 
 On the `PyMechanical Issues <https://github.com/ansys/pymechanical/issues>`_ page,
-you can create issues to submit questions, report bugs, and request new features.
-This is the best place to post questions and code.
+you can create issues to report bugs and request new features. On the `PyMechanical Discussions
+<https://github.com/ansys/pymechanical/discussions>`_ page or the `Discussions <https://discuss.ansys.com/>`_
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
 
 To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -134,8 +134,9 @@ To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@a
 
 Testing and Development
 -----------------------
-If you would like to test or contribute to the development of PyMechanical, please visit
-`PyMechanical - Contributing <https://mechanical.docs.pyansys.com/version/stable/contributing.html>`_.
+If you would like to test or contribute to the development of PyMechanical, see
+`Contribute <https://mechanical.docs.pyansys.com/version/stable/contributing.html>`_ in
+the PyMechanical documentation.
 
 .. LINKS AND REFERENCES
 .. _black: https://github.com/psf/black

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -78,6 +78,25 @@ there, Mechanical's entire data model is available for use from Python code.
 
 For information on using an embedded instance, see :ref:`ref_user_guide_embedding`.
 
+Documentation and issues
+------------------------
+Documentation for the latest stable release of PyMechanical is hosted at `PyMechanical documentation
+<https://mechanical.docs.pyansys.com/version/stable/>`_.
+
+In the upper right corner of the documentation's title bar, there is an option for switching from
+viewing the documentation for the latest stable release to viewing the documentation for the
+development version or previously released versions.
+
+You can also `view <https://cheatsheets.docs.pyansys.com/pymechanical_cheat_sheet.png>`_ or
+`download <https://cheatsheets.docs.pyansys.com/pymechanical_cheat_sheet.pdf>`_ the
+PyMechanical cheat sheet. This one-page reference provides syntax rules and commands
+for using PyMechanical. 
+
+On the `PyMechanical Issues <https://github.com/ansys/pymechanical/issues>`_ page,
+you can create issues to submit questions, report bugs, and request new features.
+This is the best place to post questions and code.
+
+To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 Project index
 *************

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -99,6 +99,6 @@ This is the best place to post questions and code.
 To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 Project index
-*************
+-------------
 
 * :ref:`genindex`

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -93,8 +93,9 @@ PyMechanical cheat sheet. This one-page reference provides syntax rules and comm
 for using PyMechanical. 
 
 On the `PyMechanical Issues <https://github.com/ansys/pymechanical/issues>`_ page,
-you can create issues to submit questions, report bugs, and request new features.
-This is the best place to post questions and code.
+you can create issues to report bugs and request new features. On the `PyMechanical Discussions
+<https://github.com/ansys/pymechanical/discussions>`_ page or the `Discussions <https://discuss.ansys.com/>`_
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
 
 To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 


### PR DESCRIPTION
Per Landon’s request in the PyAnsys Global AFT on 7/26/23, add a link to the PyMechanical cheat sheet from this library's documentation.

Note: This library doesn't reuse the README content in the overall index.rst file for documentation. Consequently, I had to add a new "Documentation and issues" section in both the README and the overall index.rst file.

@RobPasMue Landon also requested that a link to a cheat sheet be added beneath the documentation link on the repository page. However, I don't know if this can be done--and don't have the permissions to make changes to this page. If it's possible, someone with the permissions should consider adding a link--probably to the PNG file? Also, there are six more libraries that have cheat sheets. Before adding this same content to the others, I wanted your feedback on this PR and MAPDL PR #2234, which currently has four checks failing.