### PR TITLE
Set up daily run for 241 testing and added manual inputs for workflow dispatch

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -68,13 +68,14 @@ jobs:
             echo "$license_name=$revn" >> $GITHUB_OUTPUT
           }
 
-          if [[ -z "${{ inputs.default-revn }}" && -z "${{ inputs.test-revn }}" ]]; then
+          if [[ -z "${{ inputs.default-revn }}" || -z "${{ inputs.test-revn }}" ]]; then
             if ${{ github.event_name == 'schedule' }}; then
               parse_revns "${{ env.DEV_REVN }}" "default" "default_lic"
               parse_revns "${{ env.DEV_REVN }}" "test" "test_lic"
             else
               parse_revns "${{ env.DEFAULT_REVN }}" "default" "default_lic"
               parse_revns "${{ env.TEST_REVN }}" "test" "test_lic"
+            fi
           else
             parse_revns "${{ inputs.default-revn }}" "default" "default_lic"
             parse_revns "${{ inputs.test-revn }}" "test" "test_lic"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -65,15 +65,7 @@ jobs:
           test=${{ inputs.test-revn || '$revn' }}
           test_version="${test:0:2}.${test:2}.0"
           echo "test=$test_version" >> $GITHUB_OUTPUT
-          echo "test_lic=$revn" >> $GITHUB_OUTPUT
-    
-  set-env-var:
-    runs-on: ubuntu-latest
-    needs: [echo_var]
-    steps:
-      - name: Set the environment variable
-        run: echo DOCKER_IMAGE_VERSION=${{needs.echo_var.outputs.default}} >> $GITHUB_ENV
-        
+          echo "test_lic=$revn" >> $GITHUB_OUTPUT        
   style:
     name: Code style
     runs-on: ubuntu-latest
@@ -157,7 +149,7 @@ jobs:
   tests:
     name: Testing and coverage - Mechanical ${{ matrix.mechanical-version }}
     runs-on: public-ubuntu-latest-8-cores
-    needs: [smoke-tests, echo_var, set-env-var]
+    needs: [smoke-tests, echo_var]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -195,6 +187,9 @@ jobs:
       # - name: Upload coverage to Codecov
       #   uses: codecov/codecov-action@v3
 
+      - name: Set the environment variable
+        run: echo "DOCKER_IMAGE_VERSION=${{needs.echo_var.outputs.default}}" >> $GITHUB_ENV
+
       - name: Upload coverage results
         uses: actions/upload-artifact@v3
         if: matrix.mechanical-version == env.DOCKER_IMAGE_VERSION
@@ -230,7 +225,7 @@ jobs:
   embedding-tests:
     name: Embedding testing and coverage
     runs-on: ubuntu-latest
-    needs: [style, echo_var, set-env-var]
+    needs: [style, echo_var]
     container:
       image: ghcr.io/ansys/mechanical:${{needs.echo_var.outputs.test}}
       options: --entrypoint /bin/bash
@@ -303,7 +298,7 @@ jobs:
     container:
       image: ghcr.io/ansys/mechanical:${{needs.echo_var.outputs.test}}
       options: --entrypoint /bin/bash
-    needs: [ smoke-tests, echo_var, set-env-var ]
+    needs: [ smoke-tests, echo_var]
     strategy:
       fail-fast: false
       matrix:
@@ -367,9 +362,12 @@ jobs:
 
   docs:
     name: Documentation
-    needs: [docs-style, echo_var, set-env-var]
+    needs: [docs-style, echo_var]
     runs-on: public-ubuntu-latest-8-cores
     steps:
+      - name: Set the environment variable
+        run: echo "DOCKER_IMAGE_VERSION=${{needs.echo_var.outputs.default}}" >> $GITHUB_ENV
+        
       - name: Login in Github Container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,7 +1,26 @@
 name: GitHub CI
 on:
   pull_request:
+  schedule:
+    - cron: '00 21 * * *'
   workflow_dispatch:
+    inputs:
+      default-revn:
+        type: choice
+        description: 'Default revision number for containers.'
+        options: 
+        - '231'
+        - '232'
+        - '241'
+        default: '231'
+      test-revn:
+        type: choice
+        description: 'Revision number for tests.'
+        options: 
+        - '231'
+        - '232'
+        - '241'
+        default: '232'
   push:
     tags:
       - "*"
@@ -13,7 +32,6 @@ env:
   PYMECHANICAL_PORT: 10000  # default won't work on GitHub runners
   PYMECHANICAL_START_INSTANCE: FALSE
   DOCKER_PACKAGE: ghcr.io/ansys/mechanical
-  DOCKER_IMAGE_VERSION: 23.1.0
   DOCKER_MECH_CONTAINER_NAME: mechanical
   MAIN_PYTHON_VERSION: '3.10'
   PACKAGE_NAME: ansys-mechanical-core
@@ -25,7 +43,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
+  echo_var:
+    name: echo variable
+    runs-on: ubuntu-latest
+    outputs:
+      default: ${{ steps.step1.outputs.default }}
+      test: ${{ steps.step2.outputs.test }}
+    steps:
+      - id: step1
+        run: |
+          echo ${{ github.event.schedule }}
+          default=${{ inputs.default-revn || '231' }}
+          default_version="${default:0:2}.${default:2}.0"
+          echo "default=$default_version" >> $GITHUB_OUTPUT
+      - id: step2
+        run: |
+          echo ${{ github.event.schedule }}
+          
+          test=${{ inputs.test-revn || '232' }}
+          test_version="${test:0:2}.${test:2}.0"
+          echo "test=$test_version" >> $GITHUB_OUTPUT
+    
+  set-env-var:
+    runs-on: ubuntu-latest
+    needs: [echo_var]
+    steps:
+      - name: Set the environment variable
+        run: echo "DOCKER_IMAGE_VERSION=${{needs.echo_var.outputs.default}}" >> $GITHUB_ENV
+        
   style:
     name: Code style
     runs-on: ubuntu-latest
@@ -109,16 +154,18 @@ jobs:
   tests:
     name: Testing and coverage - Mechanical ${{ matrix.mechanical-version }}
     runs-on: public-ubuntu-latest-8-cores
-    needs: [smoke-tests]
+    needs: [smoke-tests, echo_var, set-env-var]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        mechanical-version: ['23.1.0']
+        # Add the experimental mechanical-version to mechanical-version
+        # matrix below once we switch to the next revn
+        mechanical-version: ['${{needs.echo_var.outputs.default}}']
         experimental: [false]
         # The following versions would be allowed to fail
         include:
-          - mechanical-version: '23.2.0'
+          - mechanical-version: '${{needs.echo_var.outputs.test}}'
             experimental: true
     steps:
       - name: Login in Github Container registry
@@ -182,7 +229,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [style]
     container:
-      image: ghcr.io/ansys/mechanical:23.2.0
+      image: ghcr.io/ansys/mechanical:${{needs.echo_var.outputs.test}}
       options: --entrypoint /bin/bash
     strategy:
       max-parallel: 2
@@ -248,7 +295,7 @@ jobs:
     name: Launch testing and coverage
     runs-on: public-ubuntu-latest-8-cores
     container:
-      image: ghcr.io/ansys/mechanical:23.2.0
+      image: ghcr.io/ansys/mechanical:${{needs.echo_var.outputs.test}}
       options: --entrypoint /bin/bash
     needs: [ smoke-tests ]
     strategy:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -37,6 +37,8 @@ env:
   PACKAGE_NAME: ansys-mechanical-core
   PACKAGE_NAMESPACE: ansys.mechanical.core
   DOCUMENTATION_CNAME: mechanical.docs.pyansys.com
+  DEFAULT_REVN: '231'
+  TEST_REVN: '232'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -49,23 +51,26 @@ jobs:
     outputs:
       default: ${{ steps.step1.outputs.default }}
       default_lic: ${{ steps.step1.outputs.default_lic }}
-      test: ${{ steps.step2.outputs.test }}
-      test_lic:  ${{ steps.step2.outputs.test_lic }}
+      test: ${{ steps.step1.outputs.test }}
+      test_lic:  ${{ steps.step1.outputs.test_lic }}
     steps:
       - id: step1
         run: |
-          revn='231'
-          default=${{ inputs.default-revn || '$revn' }}
-          default_version="${default:0:2}.${default:2}.0"
-          echo "default=$default_version" >> $GITHUB_OUTPUT
-          echo "default_lic=$revn" >> $GITHUB_OUTPUT
-      - id: step2
-        run: |
-          revn='232'
-          test=${{ inputs.test-revn || '$revn' }}
-          test_version="${test:0:2}.${test:2}.0"
-          echo "test=$test_version" >> $GITHUB_OUTPUT
-          echo "test_lic=$revn" >> $GITHUB_OUTPUT        
+          parse_revns() {
+            revn=$1
+            container_name=$2
+            license_name=$3
+
+            get_revn=${{ inputs.default-revn || '${{ env.DEFAULT_REVN }}' }}
+            container_version="${get_revn:0:2}.${get_revn:2}.0"
+            echo "$container_name=$container_version" >> $GITHUB_OUTPUT
+            echo "$license_name=$revn" >> $GITHUB_OUTPUT
+          
+          }
+
+          parse_revns "${{ env.DEFAULT_REVN }}" "default" "default_lic"
+          parse_revns "${{ env.TEST_REVN }}" "test" "test_lic"
+       
   style:
     name: Code style
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -63,9 +63,10 @@ jobs:
             container_name=$2
             license_name=$3
             
-            container_name_revn=$container_name-revn
-
-            get_revn="${{ inputs.$container_name_revn || $revn }}"
+            container_name_revn=inputs.$container_name-revn
+            echo $container_name_revn
+            
+            get_revn="${{ $container_name_revn || $revn }}"
             echo $get_revn
             container_version="${get_revn:0:2}.${get_revn:2}.0"
             echo "$container_name=$container_version" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,17 +1,5 @@
 name: GitHub CI
 
-env:
-  PYMECHANICAL_PORT: 10000  # default won't work on GitHub runners
-  PYMECHANICAL_START_INSTANCE: FALSE
-  DOCKER_PACKAGE: ghcr.io/ansys/mechanical
-  DOCKER_MECH_CONTAINER_NAME: mechanical
-  MAIN_PYTHON_VERSION: '3.10'
-  PACKAGE_NAME: ansys-mechanical-core
-  PACKAGE_NAMESPACE: ansys.mechanical.core
-  DOCUMENTATION_CNAME: mechanical.docs.pyansys.com
-  DEFAULT_REVN: '231'
-  TEST_REVN: '232'
-
 on:
   pull_request:
   schedule:
@@ -25,7 +13,7 @@ on:
         - '231'
         - '232'
         - '241'
-        default: '${{ env.DEFAULT_REVN }}'
+        default: '231'  # ensure this is the same as env.DEFAULT_REVN
       test-revn:
         type: choice
         description: 'Revision number for tests.'
@@ -33,13 +21,25 @@ on:
         - '231'
         - '232'
         - '241'
-        default: '${{ env.TEST_REVN }}'
+        default: '232'  # ensure this is the same as env.TEST_REVN
   push:
     tags:
       - "*"
     branches:
       - main
       - release/*
+
+env:
+  PYMECHANICAL_PORT: 10000  # default won't work on GitHub runners
+  PYMECHANICAL_START_INSTANCE: FALSE
+  DOCKER_PACKAGE: ghcr.io/ansys/mechanical
+  DOCKER_MECH_CONTAINER_NAME: mechanical
+  MAIN_PYTHON_VERSION: '3.10'
+  PACKAGE_NAME: ansys-mechanical-core
+  PACKAGE_NAMESPACE: ansys.mechanical.core
+  DOCUMENTATION_CNAME: mechanical.docs.pyansys.com
+  DEFAULT_REVN: '231'  # ensure this is the same as inputs.default-revn.default
+  TEST_REVN: '232'  # ensure this is the same as inputs.test-revn.default
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -55,14 +55,14 @@ jobs:
       - id: step1
         run: |
           revn='231'
-          default=${{ inputs.default-revn || $revn }}
+          default=${{ inputs.default-revn || '$revn' }}
           default_version="${default:0:2}.${default:2}.0"
           echo "default=$default_version" >> $GITHUB_OUTPUT
           echo "default_lic=$revn" >> $GITHUB_OUTPUT
       - id: step2
         run: |
           revn='232'
-          test=${{ inputs.test-revn || $revn }}
+          test=${{ inputs.test-revn || '$revn' }}
           test_version="${test:0:2}.${test:2}.0"
           echo "test=$test_version" >> $GITHUB_OUTPUT
           echo "test_lic=$revn" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -62,8 +62,11 @@ jobs:
             revn=$1
             container_name=$2
             license_name=$3
+            
+            container_name_revn=$container_name-revn
 
-            get_revn=${{ inputs.default-revn || '${{ env.DEFAULT_REVN }}' }}
+            get_revn="${{ inputs.$container_name_revn || $revn }}"
+            echo $get_revn
             container_version="${get_revn:0:2}.${get_revn:2}.0"
             echo "$container_name=$container_version" >> $GITHUB_OUTPUT
             echo "$license_name=$revn" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -62,29 +62,22 @@ jobs:
             revn=$1
             container_name=$2
             license_name=$3
-
-            if [ -z "${{ inputs.default-revn }}" ]; then
-               get_revn="$revn"
-            else
-              get_revn="${{ inputs.default-revn }}"
-            fi
             
-            echo $get_revn
-            container_version="${get_revn:0:2}.${get_revn:2}.0"
+            container_version="${revn:0:2}.${revn:2}.0"
             echo "$container_name=$container_version" >> $GITHUB_OUTPUT
             echo "$license_name=$revn" >> $GITHUB_OUTPUT
-            
-            echo $container_name
-            echo $license_name
-          
           }
 
-          if ${{ github.event_name == 'schedule' }}; then
-            parse_revns "${{ env.DEV_REVN }}" "default" "default_lic"
-            parse_revns "${{ env.DEV_REVN }}" "test" "test_lic"
+          if [[ -z "${{ inputs.default-revn }}" && -z "${{ inputs.test-revn }}" ]]; then
+            if ${{ github.event_name == 'schedule' }}; then
+              parse_revns "${{ env.DEV_REVN }}" "default" "default_lic"
+              parse_revns "${{ env.DEV_REVN }}" "test" "test_lic"
+            else
+              parse_revns "${{ env.DEFAULT_REVN }}" "default" "default_lic"
+              parse_revns "${{ env.TEST_REVN }}" "test" "test_lic"
           else
-            parse_revns "${{ env.DEFAULT_REVN }}" "default" "default_lic"
-            parse_revns "${{ env.TEST_REVN }}" "test" "test_lic"
+            parse_revns "${{ inputs.default-revn }}" "default" "default_lic"
+            parse_revns "${{ inputs.test-revn }}" "test" "test_lic"
           fi
        
   style:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -62,9 +62,12 @@ jobs:
             revn=$1
             container_name=$2
             license_name=$3
-            
-            container_name_revn=inputs.$container_name-revn
-            echo $container_name_revn
+
+            if [ "$container_name" == "default" ]; then
+              container_name_revn = $ {{ inputs.default-revn }}
+            else
+              container_name_revn = $ {{ inputs.test-revn }}
+            fi
             
             get_revn="${{ $container_name_revn || $revn }}"
             echo $get_revn

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -64,9 +64,9 @@ jobs:
             license_name=$3
 
             if [ "$container_name" == "default" ]; then
-              get_revn=${{ inputs.default-revn }}
+              get_revn="${{ inputs.default-revn }}"
             else
-              get_revn=${{ inputs.test-revn }}
+              get_revn="${{ inputs.test-revn }}"
             fi
 
             if [ -z "$get_revn" ]; then

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -72,7 +72,7 @@ jobs:
     needs: [echo_var]
     steps:
       - name: Set the environment variable
-        run: echo "DOCKER_IMAGE_VERSION=${{needs.echo_var.outputs.default}}" >> $GITHUB_ENV
+        run: echo DOCKER_IMAGE_VERSION=${{needs.echo_var.outputs.default}} >> $GITHUB_ENV
         
   style:
     name: Code style

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,32 +1,4 @@
 name: GitHub CI
-on:
-  pull_request:
-  schedule:
-    - cron: '00 21 * * *'
-  workflow_dispatch:
-    inputs:
-      default-revn:
-        type: choice
-        description: 'Default revision number for containers.'
-        options: 
-        - '231'
-        - '232'
-        - '241'
-        default: '231'
-      test-revn:
-        type: choice
-        description: 'Revision number for tests.'
-        options: 
-        - '231'
-        - '232'
-        - '241'
-        default: '232'
-  push:
-    tags:
-      - "*"
-    branches:
-      - main
-      - release/*
 
 env:
   PYMECHANICAL_PORT: 10000  # default won't work on GitHub runners
@@ -40,21 +12,50 @@ env:
   DEFAULT_REVN: '231'
   TEST_REVN: '232'
 
+on:
+  pull_request:
+  schedule:
+    - cron: '00 21 * * *'
+  workflow_dispatch:
+    inputs:
+      default-revn:
+        type: choice
+        description: 'Default revision number for containers.'
+        options: 
+        - '231'
+        - '232'
+        - '241'
+        default: '${{ env.DEFAULT_REVN }}'
+      test-revn:
+        type: choice
+        description: 'Revision number for tests.'
+        options: 
+        - '231'
+        - '232'
+        - '241'
+        default: '${{ env.TEST_REVN }}'
+  push:
+    tags:
+      - "*"
+    branches:
+      - main
+      - release/*
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  echo_var:
-    name: echo variable
+  revn-variations:
+    name: Save variations of revn
     runs-on: ubuntu-latest
     outputs:
-      default: ${{ steps.step1.outputs.default }}
-      default_lic: ${{ steps.step1.outputs.default_lic }}
-      test: ${{ steps.step1.outputs.test }}
-      test_lic:  ${{ steps.step1.outputs.test_lic }}
+      default: ${{ steps.save-versions.outputs.default }}
+      default_lic: ${{ steps.save-versions.outputs.default_lic }}
+      test: ${{ steps.save-versions.outputs.test }}
+      test_lic:  ${{ steps.save-versions.outputs.test_lic }}
     steps:
-      - id: step1
+      - id: save-versions
         run: |
           parse_revns() {
             revn=$1
@@ -154,18 +155,18 @@ jobs:
   tests:
     name: Testing and coverage - Mechanical ${{ matrix.mechanical-version }}
     runs-on: public-ubuntu-latest-8-cores
-    needs: [smoke-tests, echo_var]
+    needs: [smoke-tests, revn-variations]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         # Add the experimental mechanical-version to mechanical-version
         # matrix below once we switch to the next revn
-        mechanical-version: ['${{needs.echo_var.outputs.default}}']
+        mechanical-version: ['${{needs.revn-variations.outputs.default}}']
         experimental: [false]
         # The following versions would be allowed to fail
         include:
-          - mechanical-version: '${{needs.echo_var.outputs.test}}'
+          - mechanical-version: '${{needs.revn-variations.outputs.test}}'
             experimental: true
     steps:
       - name: Login in Github Container registry
@@ -193,7 +194,7 @@ jobs:
       #   uses: codecov/codecov-action@v3
 
       - name: Set the environment variable
-        run: echo "DOCKER_IMAGE_VERSION=${{needs.echo_var.outputs.default}}" >> $GITHUB_ENV
+        run: echo "DOCKER_IMAGE_VERSION=${{needs.revn-variations.outputs.default}}" >> $GITHUB_ENV
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v3
@@ -230,9 +231,9 @@ jobs:
   embedding-tests:
     name: Embedding testing and coverage
     runs-on: ubuntu-latest
-    needs: [style, echo_var]
+    needs: [style, revn-variations]
     container:
-      image: ghcr.io/ansys/mechanical:${{needs.echo_var.outputs.test}}
+      image: ghcr.io/ansys/mechanical:${{needs.revn-variations.outputs.test}}
       options: --entrypoint /bin/bash
     strategy:
       max-parallel: 2
@@ -255,7 +256,7 @@ jobs:
           pip install .[tests]
 
       - name: Set environment variable
-        run: echo "ANSYSCL${{ needs.echo_var.outputs.test_lic }}_DIR=/install/ansys_inc/v${{ needs.echo_var.outputs.test_lic }}/licensingclient" >> $GITHUB_ENV
+        run: echo "ANSYSCL${{ needs.revn-variations.outputs.test_lic }}_DIR=/install/ansys_inc/v${{ needs.revn-variations.outputs.test_lic }}/licensingclient" >> $GITHUB_ENV
 
       - name: Unit Testing and coverage
         env:
@@ -267,7 +268,7 @@ jobs:
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          /install/ansys_inc/v${{ needs.echo_var.outputs.test_lic }}/aisol/.workbench_lite pytest -m embedding -k logging > pytest_output.txt || true
+          /install/ansys_inc/v${{ needs.revn-variations.outputs.test_lic }}/aisol/.workbench_lite pytest -m embedding -k logging > pytest_output.txt || true
           cat pytest_output.txt
           #
           # Check if failure occurred
@@ -301,9 +302,9 @@ jobs:
     name: Launch testing and coverage
     runs-on: public-ubuntu-latest-8-cores
     container:
-      image: ghcr.io/ansys/mechanical:${{needs.echo_var.outputs.test}}
+      image: ghcr.io/ansys/mechanical:${{needs.revn-variations.outputs.test}}
       options: --entrypoint /bin/bash
-    needs: [ smoke-tests, echo_var]
+    needs: [ smoke-tests, revn-variations]
     strategy:
       fail-fast: false
       matrix:
@@ -324,7 +325,7 @@ jobs:
           pip install .[tests]
 
       - name: Set environment variable
-        run: echo "ANSYSCL${{ needs.echo_var.outputs.test_lic }}_DIR=/install/ansys_inc/v${{ needs.echo_var.outputs.test_lic }}/licensingclient" >> $GITHUB_ENV
+        run: echo "ANSYSCL${{ needs.revn-variations.outputs.test_lic }}_DIR=/install/ansys_inc/v${{ needs.revn-variations.outputs.test_lic }}/licensingclient" >> $GITHUB_ENV
 
       - name: Unit Testing and coverage
         env:
@@ -367,11 +368,11 @@ jobs:
 
   docs:
     name: Documentation
-    needs: [docs-style, echo_var]
+    needs: [docs-style, revn-variations]
     runs-on: public-ubuntu-latest-8-cores
     steps:
       - name: Set the environment variable
-        run: echo "DOCKER_IMAGE_VERSION=${{needs.echo_var.outputs.default}}" >> $GITHUB_ENV
+        run: echo "DOCKER_IMAGE_VERSION=${{needs.revn-variations.outputs.default}}" >> $GITHUB_ENV
         
       - name: Login in Github Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -64,12 +64,15 @@ jobs:
             license_name=$3
 
             if [ "$container_name" == "default" ]; then
-              container_name_revn = $ {{ inputs.default-revn }}
+              get_revn=${{ inputs.default-revn }}
             else
-              container_name_revn = $ {{ inputs.test-revn }}
+              get_revn=${{ inputs.test-revn }}
+            fi
+
+            if [ -z "$get_revn" ]; then
+               get_revn="$revn"
             fi
             
-            get_revn="${{ $container_name_revn || $revn }}"
             echo $get_revn
             container_version="${get_revn:0:2}.${get_revn:2}.0"
             echo "$container_name=$container_version" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -3,7 +3,7 @@ name: GitHub CI
 on:
   pull_request:
   schedule:
-    - cron: '36 17 * * *'
+    - cron: '00 21 * * *'
   workflow_dispatch:
     inputs:
       default-revn:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -3,7 +3,7 @@ name: GitHub CI
 on:
   pull_request:
   schedule:
-    - cron: '00 21 * * *'
+    - cron: '00 22 * * *'  # UTC time, may start 5-15 mins later than scheduled time
   workflow_dispatch:
     inputs:
       default-revn:
@@ -59,16 +59,22 @@ jobs:
       - id: save-versions
         run: |
           parse_revns() {
-            revn=$1
+            revn=$1  # For example, 231
             container_name=$2
             license_name=$3
-            
-            container_version="${revn:0:2}.${revn:2}.0"
+
+            # Create container_version from revn
+            container_version="${revn:0:2}.${revn:2}.0"  # For example, 23.1.0
+
+            # Set output variables
             echo "$container_name=$container_version" >> $GITHUB_OUTPUT
             echo "$license_name=$revn" >> $GITHUB_OUTPUT
           }
 
+          # Use default revn values if the input values were not chosen.
+          # The input values are only selected in workflow_dispatch events.
           if [[ -z "${{ inputs.default-revn }}" || -z "${{ inputs.test-revn }}" ]]; then
+            # If the event is a scheduled run, set the value to the DEV_REVN env var.
             if ${{ github.event_name == 'schedule' }}; then
               parse_revns "${{ env.DEV_REVN }}" "default" "default_lic"
               parse_revns "${{ env.DEV_REVN }}" "test" "test_lic"
@@ -77,6 +83,7 @@ jobs:
               parse_revns "${{ env.TEST_REVN }}" "test" "test_lic"
             fi
           else
+            # If the input values are selected, use those values instead of the env vars
             parse_revns "${{ inputs.default-revn }}" "default" "default_lic"
             parse_revns "${{ inputs.test-revn }}" "test" "test_lic"
           fi
@@ -270,7 +277,6 @@ jobs:
       - name: Unit Testing and coverage
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
-          # ANSYSCL232_DIR: /install/ansys_inc/v232/licensingclient
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
           ANSYS_WORKBENCH_LOGGING_CONSOLE: 0
           ANSYS_WORKBENCH_LOGGING: 0
@@ -339,7 +345,6 @@ jobs:
       - name: Unit Testing and coverage
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
-          # ANSYSCL232_DIR: /install/ansys_inc/v232/licensingclient
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
           ANSYS_WORKBENCH_LOGGING_CONSOLE: 0
         run: |

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -40,6 +40,7 @@ env:
   DOCUMENTATION_CNAME: mechanical.docs.pyansys.com
   DEFAULT_REVN: '231'  # ensure this is the same as inputs.default-revn.default
   TEST_REVN: '232'  # ensure this is the same as inputs.test-revn.default
+  DEV_REVN: '241'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -69,8 +70,13 @@ jobs:
           
           }
 
-          parse_revns "${{ env.DEFAULT_REVN }}" "default" "default_lic"
-          parse_revns "${{ env.TEST_REVN }}" "test" "test_lic"
+          if ${{ github.event_name == 'schedule' }}; then
+            parse_revns "${{ env.DEV_REVN }}" "default" "default_lic"
+            parse_revns "${{ env.DEV_REVN }}" "test" "test_lic"
+          else
+            parse_revns "${{ env.DEFAULT_REVN }}" "default" "default_lic"
+            parse_revns "${{ env.TEST_REVN }}" "test" "test_lic"
+          fi
        
   style:
     name: Code style

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -230,7 +230,7 @@ jobs:
   embedding-tests:
     name: Embedding testing and coverage
     runs-on: ubuntu-latest
-    needs: [style]
+    needs: [style, echo_var, set-env-var]
     container:
       image: ghcr.io/ansys/mechanical:${{needs.echo_var.outputs.test}}
       options: --entrypoint /bin/bash
@@ -303,7 +303,7 @@ jobs:
     container:
       image: ghcr.io/ansys/mechanical:${{needs.echo_var.outputs.test}}
       options: --entrypoint /bin/bash
-    needs: [ smoke-tests ]
+    needs: [ smoke-tests, echo_var, set-env-var ]
     strategy:
       fail-fast: false
       matrix:
@@ -367,7 +367,7 @@ jobs:
 
   docs:
     name: Documentation
-    needs: [docs-style]
+    needs: [docs-style, echo_var, set-env-var]
     runs-on: public-ubuntu-latest-8-cores
     steps:
       - name: Login in Github Container registry

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -3,7 +3,7 @@ name: GitHub CI
 on:
   pull_request:
   schedule:
-    - cron: '00 21 * * *'
+    - cron: '36 17 * * *'
   workflow_dispatch:
     inputs:
       default-revn:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -48,21 +48,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       default: ${{ steps.step1.outputs.default }}
+      default_lic: ${{ steps.step1.outputs.default_lic }}
       test: ${{ steps.step2.outputs.test }}
+      test_lic:  ${{ steps.step2.outputs.test_lic }}
     steps:
       - id: step1
         run: |
-          echo ${{ github.event.schedule }}
-          default=${{ inputs.default-revn || '231' }}
+          revn='231'
+          default=${{ inputs.default-revn || $revn }}
           default_version="${default:0:2}.${default:2}.0"
           echo "default=$default_version" >> $GITHUB_OUTPUT
+          echo "default_lic=$revn" >> $GITHUB_OUTPUT
       - id: step2
         run: |
-          echo ${{ github.event.schedule }}
-          
-          test=${{ inputs.test-revn || '232' }}
+          revn='232'
+          test=${{ inputs.test-revn || $revn }}
           test_version="${test:0:2}.${test:2}.0"
           echo "test=$test_version" >> $GITHUB_OUTPUT
+          echo "test_lic=$revn" >> $GITHUB_OUTPUT
     
   set-env-var:
     runs-on: ubuntu-latest
@@ -251,17 +254,20 @@ jobs:
         run: |
           pip install .[tests]
 
+      - name: Set environment variable
+        run: echo "ANSYSCL${{ needs.echo_var.outputs.test_lic }}_DIR=/install/ansys_inc/v${{ needs.echo_var.outputs.test_lic }}/licensingclient" >> $GITHUB_ENV
+
       - name: Unit Testing and coverage
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
-          ANSYSCL232_DIR: /install/ansys_inc/v232/licensingclient
+          # ANSYSCL232_DIR: /install/ansys_inc/v232/licensingclient
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
           ANSYS_WORKBENCH_LOGGING_CONSOLE: 0
           ANSYS_WORKBENCH_LOGGING: 0
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          /install/ansys_inc/v232/aisol/.workbench_lite pytest -m embedding -k logging > pytest_output.txt || true
+          /install/ansys_inc/v${{ needs.echo_var.outputs.test_lic }}/aisol/.workbench_lite pytest -m embedding -k logging > pytest_output.txt || true
           cat pytest_output.txt
           #
           # Check if failure occurred
@@ -317,10 +323,13 @@ jobs:
         run: |
           pip install .[tests]
 
+      - name: Set environment variable
+        run: echo "ANSYSCL${{ needs.echo_var.outputs.test_lic }}_DIR=/install/ansys_inc/v${{ needs.echo_var.outputs.test_lic }}/licensingclient" >> $GITHUB_ENV
+
       - name: Unit Testing and coverage
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
-          ANSYSCL232_DIR: /install/ansys_inc/v232/licensingclient
+          # ANSYSCL232_DIR: /install/ansys_inc/v232/licensingclient
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
           ANSYS_WORKBENCH_LOGGING_CONSOLE: 0
         run: |

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -10,17 +10,17 @@ on:
         type: choice
         description: 'Default revision number for containers.'
         options: 
-        - '231'
-        - '232'
         - '241'
+        - '232'
+        - '231'
         default: '231'  # ensure this is the same as env.DEFAULT_REVN
       test-revn:
         type: choice
         description: 'Revision number for tests.'
         options: 
-        - '231'
-        - '232'
         - '241'
+        - '232'
+        - '231'
         default: '232'  # ensure this is the same as env.TEST_REVN
   push:
     tags:
@@ -63,20 +63,19 @@ jobs:
             container_name=$2
             license_name=$3
 
-            if [ "$container_name" == "default" ]; then
-              get_revn="${{ inputs.default-revn }}"
-            else
-              get_revn="${{ inputs.test-revn }}"
-            fi
-
-            if [ -z "$get_revn" ]; then
+            if [ -z "${{ inputs.default-revn }}" ]; then
                get_revn="$revn"
+            else
+              get_revn="${{ inputs.default-revn }}"
             fi
             
             echo $get_revn
             container_version="${get_revn:0:2}.${get_revn:2}.0"
             echo "$container_name=$container_version" >> $GITHUB_OUTPUT
             echo "$license_name=$revn" >> $GITHUB_OUTPUT
+            
+            echo $container_name
+            echo $license_name
           
           }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ## [Unreleased][]
 
+## Added
+
+- Set up daily run for 241 testing and added manual inputs for workflow dispatch (#385)
+
+## [0.10.2](https://github.com/ansys/pymechanical/releases/tag/v0.10.2) - September 8, 2023
+
 ### Added
 
 -   Max parallel 2 for embedding tests - ci_cd.yml (#341)


### PR DESCRIPTION
Added scheduled cron to run the tests in ci_cd.yaml using 241 only. 
- Note: the scheduled cron only runs on the main branch. Depending on how busy the github runners are, there may be a 5-15 minute delay in the workflow actually running. If it's delayed for too long, it will skip the run altogether. We may need to troubleshoot a different time if it ends up skipping the scheduled run each day. 
- The cron is in UTC time, so it runs at 5pm CT, 6pm EST, and midnight CEST.

Added inputs to the workflow_dispatch to give flexibility in testing code for different revisions. Currently, the default revision is 231, and the test revision is 232. The test revision is 232 because it was listed in the "experimental" section of the tests, where tests under that revision are allowed to fail. 

This closes #363.