### PR TITLE
use Application.Exit() in 241+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 ### Fixed
 
 -   Fix embedded testing for all python version in CI/CD ([#393](https://github.com/ansys/pymechanical/pull/393))
+-   use Application.Exit() in 241+ (#396)
 
 ## [0.10.2](https://github.com/ansys/pymechanical/releases/tag/v0.10.2) - September 8, 2023
 

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -156,7 +156,10 @@ class App:
 
     def exit(self):
         """Exit the application."""
-        self.ExtAPI.Application.Close()
+        if self.version < 241:
+            self.ExtAPI.Application.Close()
+        else:
+            self.ExtAPI.Application.Exit()
 
     def execute_script(self, script: str):
         """Execute the given script with the internal IronPython engine."""


### PR DESCRIPTION
Fixes #365 