### PR TITLE
Adding Test case for export off screen image from Mechanical

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -306,7 +306,7 @@ jobs:
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          xvfb-run /install/ansys_inc/v${{ needs.revn-variations.outputs.test_lic }}/aisol/.workbench_lite pytest -m embedding > pytest_output.txt || true
+          /install/ansys_inc/v${{ needs.revn-variations.outputs.test_lic }}/aisol/.workbench_lite pytest -m embedding -k logging > pytest_output.txt || true
           cat pytest_output.txt
           #
           # Check if failure occurred

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -306,7 +306,7 @@ jobs:
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          /install/ansys_inc/v${{ needs.revn-variations.outputs.test_lic }}/aisol/.workbench_lite pytest -m embedding -k logging > pytest_output.txt || true
+          /install/ansys_inc/v${{ needs.revn-variations.outputs.test_lic }}/aisol/.workbench_lite pytest -m embedding -k test_image_export > pytest_output.txt || true
           cat pytest_output.txt
           #
           # Check if failure occurred

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -306,7 +306,7 @@ jobs:
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          xvfb-run /install/ansys_inc/v${{ needs.revn-variations.outputs.test_lic }}/aisol/.workbench_lite pytest -m embedding -k test_image_export > pytest_output.txt || true
+          xvfb-run /install/ansys_inc/v${{ needs.revn-variations.outputs.test_lic }}/aisol/.workbench_lite pytest -m embedding > pytest_output.txt || true
           cat pytest_output.txt
           #
           # Check if failure occurred

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -306,7 +306,7 @@ jobs:
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          /install/ansys_inc/v${{ needs.revn-variations.outputs.test_lic }}/aisol/.workbench_lite pytest -m embedding -k test_image_export > pytest_output.txt || true
+          xvfb-run /install/ansys_inc/v${{ needs.revn-variations.outputs.test_lic }}/aisol/.workbench_lite pytest -m embedding -k test_image_export > pytest_output.txt || true
           cat pytest_output.txt
           #
           # Check if failure occurred

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 -   add option to include enums in global variables (#394)
 -   add experimental libraries method (#395)
 -   add nonblocking sleep (#399)
+-   Add test case for exporting off screen image([#400](https://github.com/ansys/pymechanical/pull/400))
 
 ### Fixed
 

--- a/tests/embedding/test_qk_eng_wb2.py
+++ b/tests/embedding/test_qk_eng_wb2.py
@@ -274,3 +274,35 @@ def test_qk_eng_wb2_007(printer, selection, embedded_app):
         ), "Minimum Safety Factor For Fatigue Tool 2"
 
     _innertest()
+
+
+@pytest.mark.embedding
+def test_image_export(printer, selection, embedded_app):
+    """Image export.
+
+    Testing offscreen image export
+    """
+    globals().update(global_variables(embedded_app))
+    Model.AddStaticStructuralAnalysis()
+    Model.AddEigenvalueBucklingAnalysis()
+    Model.Analyses[1].InitialConditions[0].PreStressICEnvironment = Model.Analyses[0]
+    geometry_file = os.path.join(get_assets_folder(), "Eng157.x_t")
+    printer(f"Setting up test - attaching geometry {geometry_file}")
+    geometry_import = Model.GeometryImportGroup.AddGeometryImport()
+    geometry_import.Import(geometry_file)
+
+    ExtAPI.Graphics.Camera.SetFit()
+    image_export_format = Ansys.Mechanical.DataModel.Enums.GraphicsImageExportFormat.PNG
+    settings_720p = Ansys.Mechanical.Graphics.GraphicsImageExportSettings()
+    settings_720p.Resolution = (
+        Ansys.Mechanical.DataModel.Enums.GraphicsResolutionType.EnhancedResolution
+    )
+    settings_720p.Background = Ansys.Mechanical.DataModel.Enums.GraphicsBackgroundType.White
+    settings_720p.Width = 1280
+    # settings_720p.Capture = Ansys.Mechanical.DataModel.Enums.GraphicsCaptureType.ImageOnly
+    settings_720p.Height = 720
+    settings_720p.CurrentGraphicsDisplay = False
+    ExtAPI.Graphics.ExportImage(
+        os.path.join(os.getcwd(), "geometry.png"), image_export_format, settings_720p
+    )
+    assert os.path.isfile(os.path.join(os.getcwd(), "geometry.png"))


### PR DESCRIPTION
- [x]  patch the Docker image of 232 with below files 
         - .workbench_lite
         - DSTreeScript.js
        https://github.com/ansys/pymechanical/pkgs/container/mechanical

- [x] Run pymechanical tests
     https://github.com/ansys/pymechanical/actions/runs/6217148574
- [x] Run export image test only (since we haven't enabled all embedding tests)
      https://github.com/ansys/pymechanical/actions/runs/6217493970/job/16872662814#step:11:1
      