### PR TITLE
unset all logging environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
  - Fix enum printout ([#421](https://github.com/ansys/pymechanical/pull/421))
  - fix appdata tests ([#425](https://github.com/ansys/pymechanical/pull/425))
+ - unset all logging environment variables ([#434](https://github.com/ansys/pymechanical/pull/434))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-All notable changes to Python.NET will be documented in this file. This
+All notable changes to PyMechanical will be documented in this file. This
 project adheres to [Semantic Versioning](https://semver.org/).
 
 This document follows the conventions laid out in [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0).

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -5,15 +5,23 @@ import sys
 
 import pytest
 
-
 def _run_embedding_log_test_process(rootdir, pytestconfig, testname) -> subprocess.Popen:
     """Runs the process and returns it after it finishes"""
     version = pytestconfig.getoption("ansys_version")
     embedded_py = os.path.join(rootdir, "tests", "scripts", "embedding_log_test.py")
+
+    # unset all logging environment variables.
+    env = os.environ.copy()
+    del env["ANSYS_WORKBENCH_LOGGING"]
+    del env["ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL"]
+    del env["ANSYS_WORKBENCH_LOGGING_CONSOLE"]
+    del env["ANSYS_WORKBENCH_LOGGING_AUTO_FLUSH"]
+    del env["ANSYS_WORKBENCH_LOGGING_DIRECTORY"]
     p = subprocess.Popen(
         [sys.executable, embedded_py, version, testname],
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
+        env=env,
     )
     p.wait()
     return p

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -5,24 +5,31 @@ import sys
 
 import pytest
 
+def _unset_var(env, var) -> None:
+    if var in env:
+        del env[var]
+
+
+def _get_env_without_logging_variables():
+    # unset all logging environment variables.
+    env = os.environ.copy()
+    _unset_var(env, "ANSYS_WORKBENCH_LOGGING")
+    _unset_var(env, "ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL")
+    _unset_var(env, "ANSYS_WORKBENCH_LOGGING_CONSOLE")
+    _unset_var(env, "ANSYS_WORKBENCH_LOGGING_AUTO_FLUSH")
+    _unset_var(env, "ANSYS_WORKBENCH_LOGGING_DIRECTORY")
+    return env
+
 
 def _run_embedding_log_test_process(rootdir, pytestconfig, testname) -> subprocess.Popen:
     """Runs the process and returns it after it finishes"""
     version = pytestconfig.getoption("ansys_version")
     embedded_py = os.path.join(rootdir, "tests", "scripts", "embedding_log_test.py")
-
-    # unset all logging environment variables.
-    env = os.environ.copy()
-    del env["ANSYS_WORKBENCH_LOGGING"]
-    del env["ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL"]
-    del env["ANSYS_WORKBENCH_LOGGING_CONSOLE"]
-    del env["ANSYS_WORKBENCH_LOGGING_AUTO_FLUSH"]
-    del env["ANSYS_WORKBENCH_LOGGING_DIRECTORY"]
     p = subprocess.Popen(
         [sys.executable, embedded_py, version, testname],
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
-        env=env,
+        env=_get_env_without_logging_variables(),
     )
     p.wait()
     return p

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -5,6 +5,7 @@ import sys
 
 import pytest
 
+
 def _unset_var(env, var) -> None:
     if var in env:
         del env[var]

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -5,6 +5,7 @@ import sys
 
 import pytest
 
+
 def _run_embedding_log_test_process(rootdir, pytestconfig, testname) -> subprocess.Popen:
     """Runs the process and returns it after it finishes"""
     version = pytestconfig.getoption("ansys_version")


### PR DESCRIPTION
before running embedding_log_test.py
that script sets logging environments and these could conflict with it

The env vars set in the docker container were affecting test runs against 241