### PR TITLE
pytest --ansys-version dependent on existing install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
  - fix appdata tests ([#425](https://github.com/ansys/pymechanical/pull/425))
  - Run all embedding tests & fix appdata tests ([#433](https://github.com/ansys/pymechanical/pull/433))
  - unset all logging environment variables ([#434](https://github.com/ansys/pymechanical/pull/434))
+ - pytest --ansys-version dependent on existing install ([#439](https://github.com/ansys/pymechanical/pull/439))
 
 ### Changed
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 
-import ansys.tools.path
+import ansys.tools.path as atp
 import pytest
 
 import ansys.mechanical.core as pymechanical
@@ -117,7 +117,7 @@ EMBEDDED_APP = None
 @pytest.fixture(scope="session")
 def embedded_app(pytestconfig, request):
     global EMBEDDED_APP
-    startup_time = start_embedding_app(pytestconfig.getoption("ansys_version"), pytestconfig)
+    startup_time = start_embedding_app(pytestconfig.getoption("--ansys-version"), pytestconfig)
     terminal_reporter = request.config.pluginmanager.getplugin("terminalreporter")
     if terminal_reporter is not None:
         terminal_reporter.write_line(f"\t{startup_time}\tStarting Mechanical")
@@ -273,7 +273,7 @@ def mechanical_pool():
     if not pymechanical.mechanical.get_start_instance():
         return None
 
-    path, version = ansys.tools.path.find_mechanical()
+    path, version = atp.find_mechanical()
 
     exec_file = path
     instances_count = 2
@@ -299,8 +299,17 @@ def mechanical_pool():
 
 
 def pytest_addoption(parser):
+    mechanical_path = atp.get_mechanical_path()
+
+    print(mechanical_path)
+
+    if mechanical_path == None:
+        parser.addoption("--ansys-version", default="232")
+    else:
+        mechanical_version = atp.version_from_path("mechanical", mechanical_path)
+        parser.addoption("--ansys-version", default=mechanical_version)
+
     # parser.addoption("--debugging", action="store_true")
-    parser.addoption("--ansys-version", default="232")
     parser.addoption("--addin-configuration", default="Mechanical")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -307,7 +307,7 @@ def pytest_addoption(parser):
         parser.addoption("--ansys-version", default="232")
     else:
         mechanical_version = atp.version_from_path("mechanical", mechanical_path)
-        parser.addoption("--ansys-version", default=mechanical_version)
+        parser.addoption("--ansys-version", default=str(mechanical_version))
 
     # parser.addoption("--debugging", action="store_true")
     parser.addoption("--addin-configuration", default="Mechanical")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,7 @@ EMBEDDED_APP = None
 @pytest.fixture(scope="session")
 def embedded_app(pytestconfig, request):
     global EMBEDDED_APP
-    startup_time = start_embedding_app(pytestconfig.getoption("--ansys-version"), pytestconfig)
+    startup_time = start_embedding_app(pytestconfig.getoption("ansys-version"), pytestconfig)
     terminal_reporter = request.config.pluginmanager.getplugin("terminalreporter")
     if terminal_reporter is not None:
         terminal_reporter.write_line(f"\t{startup_time}\tStarting Mechanical")
@@ -299,9 +299,7 @@ def mechanical_pool():
 
 
 def pytest_addoption(parser):
-    mechanical_path = atp.get_mechanical_path()
-
-    print(mechanical_path)
+    mechanical_path = atp.get_mechanical_path(False)
 
     if mechanical_path == None:
         parser.addoption("--ansys-version", default="232")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,7 @@ EMBEDDED_APP = None
 @pytest.fixture(scope="session")
 def embedded_app(pytestconfig, request):
     global EMBEDDED_APP
-    startup_time = start_embedding_app(pytestconfig.getoption("ansys-version"), pytestconfig)
+    startup_time = start_embedding_app(pytestconfig.getoption("ansys_version"), pytestconfig)
     terminal_reporter = request.config.pluginmanager.getplugin("terminalreporter")
     if terminal_reporter is not None:
         terminal_reporter.write_line(f"\t{startup_time}\tStarting Mechanical")


### PR DESCRIPTION
Make pytest fixture, --ansys-version, dependent on the existing install. If it can't find one, then it defaults to 232

Closes #435 