### PR TITLE
Adds a check if path is None. app.save() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
  - Run all embedding tests & fix appdata tests ([#433](https://github.com/ansys/pymechanical/pull/433))
  - unset all logging environment variables ([#434](https://github.com/ansys/pymechanical/pull/434))
  - pytest --ansys-version dependent on existing install ([#439](https://github.com/ansys/pymechanical/pull/439))
+ - Fix app.save method for saving already saved project in current session (https://github.com/ansys/pymechanical/pull/452)
 
 ### Changed
 

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -164,7 +164,10 @@ class App:
 
     def save(self, path=None):
         """Save the project."""
-        self.DataModel.Project.Save(path)
+        if path is not None:
+            self.DataModel.Project.Save(path)
+        else:
+            self.DataModel.Project.Save()
 
     def save_as(self, path):
         """Save the project as."""


### PR DESCRIPTION
app.save() should be able to save already saved project as well. if we send None in DataModel.Project.Save(None) mechanical API then it throws error "Null or Empty File Path."

![image](https://github.com/ansys/pymechanical/assets/60212378/13d431df-1b94-4e87-b66c-0681409d475a)

This is fix for issue: https://github.com/ansys/pymechanical/issues/451