### PR TITLE
Flexible version for embedding & remote example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
  - Run all embedding tests & fix appdata tests ([#433](https://github.com/ansys/pymechanical/pull/433))
  - unset all logging environment variables ([#434](https://github.com/ansys/pymechanical/pull/434))
  - pytest --ansys-version dependent on existing install ([#439](https://github.com/ansys/pymechanical/pull/439))
- - Fix app.save method for saving already saved project in current session (https://github.com/ansys/pymechanical/pull/453)
+ - Fix app.save method for saving already saved project in current session ([#453](https://github.com/ansys/pymechanical/pull/453))
+ - Flexible version for embedding & remote example ([#459](https://github.com/ansys/pymechanical/pull/459))
 
 ### Changed
 

--- a/examples/embedding_n_remote/embedding_remote.py
+++ b/examples/embedding_n_remote/embedding_remote.py
@@ -20,7 +20,7 @@ an embedding instance and then demonstrates how to use a remote session.
 
 import os
 
-from ansys.tools.path import find_mechanical
+from ansys.tools.path import find_mechanical, version_from_path
 
 import ansys.mechanical.core as mech
 from ansys.mechanical.core.examples import download_file
@@ -35,9 +35,10 @@ print(f"Downloaded the geometry file to: {geometry_path}")
 # Find the mechanical installation path & version.
 # Open an embedded instance of Mechanical and set global variables.
 
-path, version = find_mechanical()
-
-if not version:
+try:
+    path, version = find_mechanical()
+    version = version_from_path("mechanical", path)
+except:
     version = 232
 
 app = mech.App(version=version)

--- a/examples/embedding_n_remote/embedding_remote.py
+++ b/examples/embedding_n_remote/embedding_remote.py
@@ -20,9 +20,10 @@ an embedding instance and then demonstrates how to use a remote session.
 
 import os
 
+from ansys.tools.path import find_mechanical
+
 import ansys.mechanical.core as mech
 from ansys.mechanical.core.examples import download_file
-from ansys.tools.path import find_mechanical
 
 geometry_path = download_file("Valve.pmdb", "pymechanical", "embedding")
 print(f"Downloaded the geometry file to: {geometry_path}")

--- a/examples/embedding_n_remote/embedding_remote.py
+++ b/examples/embedding_n_remote/embedding_remote.py
@@ -22,6 +22,7 @@ import os
 
 import ansys.mechanical.core as mech
 from ansys.mechanical.core.examples import download_file
+from ansys.tools.path import find_mechanical
 
 geometry_path = download_file("Valve.pmdb", "pymechanical", "embedding")
 print(f"Downloaded the geometry file to: {geometry_path}")
@@ -30,9 +31,15 @@ print(f"Downloaded the geometry file to: {geometry_path}")
 ###############################################################################
 # Embed Mechanical and set global variables
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Find the mechanical installation path & version.
 # Open an embedded instance of Mechanical and set global variables.
 
-app = mech.App(version=232)
+path, version = find_mechanical()
+
+if not version:
+    version = 232
+
+app = mech.App(version=version)
 globals().update(mech.global_variables(app))
 print(app)
 


### PR DESCRIPTION
Use ansys tool path to determine the version of the mechanical install on the system. If it can't find an install, the version defaults to 232