### PR TITLE
change which revisions are stable & dev in workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -235,7 +235,7 @@ jobs:
   embedding-tests:
     name: Embedding testing and coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 10
     needs: [style, revn-variations]
     container:
       image: ${{ needs.revn-variations.outputs.test_container }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -234,7 +234,7 @@ jobs:
 
   embedding-tests:
     name: Embedding testing and coverage
-    runs-on: public-ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 8
     needs: [style, revn-variations]
     container:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -281,7 +281,7 @@ jobs:
           NUM_CORES: 1
         run: |
           run_pytest() {
-            xvfb-run mechanical-env pytest -m embedding | tee pytest_output.txt
+            xvfb-run mechanical-env pytest -m embedding -s | tee pytest_output.txt
           }
 
           run_pytest || true

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -281,7 +281,7 @@ jobs:
           NUM_CORES: 1
         run: |
           run_pytest() {
-            xvfb-run mechanical-env pytest -m embedding -s | tee pytest_output.txt
+            xvfb-run mechanical-env pytest -m embedding --timeout=180 --timeout_method=thread | tee pytest_output.txt
           }
 
           run_pytest || true

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -235,7 +235,7 @@ jobs:
   embedding-tests:
     name: Embedding testing and coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     needs: [style, revn-variations]
     container:
       image: ${{ needs.revn-variations.outputs.test_container }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -281,7 +281,7 @@ jobs:
           NUM_CORES: 1
         run: |
           run_pytest() {
-            xvfb-run mechanical-env pytest -m embedding --timeout=180 --timeout_method=thread | tee pytest_output.txt
+            xvfb-run mechanical-env pytest -m embedding --timeout=180 --timeout_method=thread -s | tee pytest_output.txt
           }
 
           run_pytest || true

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -235,7 +235,7 @@ jobs:
   embedding-tests:
     name: Embedding testing and coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: [style, revn-variations]
     container:
       image: ${{ needs.revn-variations.outputs.test_container }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -280,18 +280,20 @@ jobs:
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          xvfb-run mechanical-env pytest -m embedding -s > pytest_output.txt || true
+          xvfb-run mechanical-env pytest -m embedding -s || true
 
-          cat pytest_output.txt
-          # Check if failure occurred
-          output=$(grep -c "FAILURES" pytest_output.txt || true)
-          if [ $output -eq 0 ]; then
-            echo "Pytest execution succeeded"
-            exit 0
-          else
-            echo "Pytest execution failed"
-            exit 1
-          fi
+          # xvfb-run mechanical-env pytest -m embedding -s > pytest_output.txt || true
+
+          # cat pytest_output.txt
+          # # Check if failure occurred
+          # output=$(grep -c "FAILURES" pytest_output.txt || true)
+          # if [ $output -eq 0 ]; then
+          #   echo "Pytest execution succeeded"
+          #   exit 0
+          # else
+          #   echo "Pytest execution failed"
+          #   exit 1
+          # fi
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -280,7 +280,7 @@ jobs:
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          xvfb-run mechanical-env pytest -m embedding --junitxml test_results${{ matrix.python-version }}.xml || true
+          xvfb-run mechanical-env pytest -m embedding -s --junitxml test_results${{ matrix.python-version }}.xml || true
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -280,20 +280,7 @@ jobs:
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          xvfb-run mechanical-env pytest -m embedding -s || true
-
-          # xvfb-run mechanical-env pytest -m embedding -s > pytest_output.txt || true
-
-          # cat pytest_output.txt
-          # # Check if failure occurred
-          # output=$(grep -c "FAILURES" pytest_output.txt || true)
-          # if [ $output -eq 0 ]; then
-          #   echo "Pytest execution succeeded"
-          #   exit 0
-          # else
-          #   echo "Pytest execution failed"
-          #   exit 1
-          # fi
+          xvfb-run mechanical-env pytest -m embedding --junitxml test_results${{ matrix.python-version }}.xml || true
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v4
@@ -310,6 +297,16 @@ jobs:
           name: coverage-file-tests-embedding
           path: .coverage
           retention-days: 7
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/test_results*.xml'
+          check_name: Test Report ${{ matrix.python-version }}
+          detailed_summary: true
+          include_passed: true
+          fail_on_failure: true
 
   launch-tests:
     name: Launch testing and coverage

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -281,7 +281,7 @@ jobs:
           NUM_CORES: 1
         run: |
           run_pytest() {
-            xvfb-run mechanical-env pytest -m embedding --timeout=180 --timeout_method=thread -s | tee pytest_output.txt
+            xvfb-run mechanical-env pytest -m embedding -s | tee pytest_output.txt
           }
 
           run_pytest || true

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -280,12 +280,9 @@ jobs:
           ANSYS_WORKBENCH_LOGGING_FILTER_LEVEL: 2
           NUM_CORES: 1
         run: |
-          run_pytest() {
-            xvfb-run mechanical-env pytest -m embedding -s | tee pytest_output.txt
-          }
+          xvfb-run mechanical-env pytest -m embedding -s > pytest_output.txt || true
 
-          run_pytest || true
-
+          cat pytest_output.txt
           # Check if failure occurred
           output=$(grep -c "FAILURES" pytest_output.txt || true)
           if [ $output -eq 0 ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ tests = [
     "pytest==7.4.4",
     "pytest-cov==4.1.0",
     "pytest-print==1.0.0",
+    "pytest-timeout"
 ]
 doc = [
     "Sphinx==7.2.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ output = ".cov/coverage.xml"
 [tool.pytest.ini_options]
 minversion = "7.1"
 addopts = """-ra -s -m remote_session_connect --durations=0 --cov=ansys.mechanical --cov-report html:.cov/html \
- --cov-report xml:.cov/xml --cov-report term -vv --print --print-relative-time"""
+ --cov-report xml:.cov/xml --cov-report term --junitxml test_results.xml -vv --print --print-relative-time"""
 # addopts = """-ra -s -m remote_session_launch --durations=0 --cov=ansys.mechanical --cov-report html:.cov/html \
 # --cov-report xml:.cov/xml --cov-report term -vv --print --print-relative-time"""
 # addopts = """-ra -s -m 'remote_session_launch or remote_session_connect' --durations=0 --cov=ansys.mechanical \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -209,9 +209,9 @@ def test_env():
 
     yield test_env_object
 
-    # print(f"\ndeleting virtual environment in {venv_dir}")
+    print(f"\ndeleting virtual environment in {venv_dir}")
     shutil.rmtree(venv_dir)
-    # print(f"deleted virtual environment in {venv_dir}\n")
+    print(f"deleted virtual environment in {venv_dir}\n")
 
 
 def launch_mechanical_instance(cleanup_on_exit=False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,12 +200,12 @@ def test_env():
     test_env_object = TestEnv()
 
     # Create virtual environment
-    subprocess.run([sys.executable, "-m", "venv", venv_dir], env=env_copy)
+    subprocess.run([sys.executable, "-m", "venv", venv_dir], env=env_copy, close_fds=True)
     # print(f"created virtual environment in {venv_dir}")
 
     # Upgrade pip
     cmdline = [test_env_object.python, "-m", "pip", "install", "-U", "pip"]
-    subprocess.check_call(cmdline, env=test_env_object.env)
+    subprocess.check_call(cmdline, env=test_env_object.env, close_fds=True)
 
     yield test_env_object
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -209,9 +209,9 @@ def test_env():
 
     yield test_env_object
 
-    print(f"\ndeleting virtual environment in {venv_dir}")
+    # print(f"\ndeleting virtual environment in {venv_dir}")
     shutil.rmtree(venv_dir)
-    print(f"deleted virtual environment in {venv_dir}\n")
+    # print(f"deleted virtual environment in {venv_dir}\n")
 
 
 def launch_mechanical_instance(cleanup_on_exit=False):

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -142,6 +142,9 @@ def test_pythonnet_warning(test_env, pytestconfig, rootdir):
     # Assert warning message appears for embedded app
     assert warning, "UserWarning should appear in the output of the script"
 
+    # Kill the check_warning subprocess
+    check_warning.kill()
+
 
 @pytest.mark.embedding
 @pytest.mark.timeout(90)

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -156,15 +156,6 @@ def test_warning_message(test_env, pytestconfig, rootdir):
     assert warning, "UserWarning should appear in the output of the script"
 
 
-# def print_stderr(process):
-#     while True:
-#         line = process.stderr.readline()
-#         if not line:
-#             break
-#         print(line.rstrip().decode())
-#     # time.sleep(0.001)
-
-
 @pytest.mark.embedding
 def test_private_appdata(pytestconfig, rootdir):
     """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
@@ -178,7 +169,6 @@ def test_private_appdata(pytestconfig, rootdir):
         stderr=subprocess.PIPE,
         close_fds=True,
     )
-    # print_stderr(p1)
     p1.communicate()
 
     # Check ShowTriad is True for private_appdata embedded sessions
@@ -188,7 +178,6 @@ def test_private_appdata(pytestconfig, rootdir):
         stderr=subprocess.PIPE,
         close_fds=True,
     )
-    # print_stderr(p2)
     stdout, stderr = p2.communicate()
 
     assert "ShowTriad value is True" in stdout.decode()
@@ -207,7 +196,6 @@ def test_normal_appdata(pytestconfig, rootdir):
         stderr=subprocess.PIPE,
         close_fds=True,
     )
-    # print_stderr(p1)
     p1.communicate()
 
     # Check ShowTriad is False for regular embedded session
@@ -217,7 +205,6 @@ def test_normal_appdata(pytestconfig, rootdir):
         stderr=subprocess.PIPE,
         close_fds=True,
     )
-    # print_stderr(p2)
     stdout, stderr = p2.communicate()
 
     # Set ShowTriad back to True for regular embedded session
@@ -227,7 +214,6 @@ def test_normal_appdata(pytestconfig, rootdir):
         stderr=subprocess.PIPE,
         close_fds=True,
     )
-    # print_stderr(p3)
     p3.communicate()
 
     # Assert ShowTriad was set to False for regular embedded session

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -25,94 +25,93 @@
 import os
 import subprocess
 import sys
+from tempfile import NamedTemporaryFile
+import time
 
 import pytest
 
-# from tempfile import NamedTemporaryFile
-# import time
+import ansys.mechanical.core.embedding.utils as utils
 
 
-# import ansys.mechanical.core.embedding.utils as utils
-
-# @pytest.mark.embedding
-# def test_app_repr(embedded_app):
-#     """Test repr of the Application class."""
-#     app_repr_lines = repr(embedded_app).splitlines()
-#     assert app_repr_lines[0].startswith("Ansys Mechanical")
-#     assert app_repr_lines[1].startswith("Product Version")
-#     assert app_repr_lines[2].startswith("Software build date:")
+@pytest.mark.embedding
+def test_app_repr(embedded_app):
+    """Test repr of the Application class."""
+    app_repr_lines = repr(embedded_app).splitlines()
+    assert app_repr_lines[0].startswith("Ansys Mechanical")
+    assert app_repr_lines[1].startswith("Product Version")
+    assert app_repr_lines[2].startswith("Software build date:")
 
 
-# @pytest.mark.embedding
-# @pytest.mark.minimum_version(241)
-# def test_deprecation_warning(embedded_app):
-#     struct = embedded_app.Model.AddStaticStructuralAnalysis()
-#     with pytest.warns(UserWarning):
-#         struct.SystemID
+@pytest.mark.embedding
+@pytest.mark.minimum_version(241)
+def test_deprecation_warning(embedded_app):
+    struct = embedded_app.Model.AddStaticStructuralAnalysis()
+    with pytest.warns(UserWarning):
+        struct.SystemID
 
 
-# @pytest.mark.embedding
-# def test_app_save_open(embedded_app, tmp_path: pytest.TempPathFactory):
-#     """Test save and open of the Application class."""
-#     import System
-#     import clr  # noqa: F401
+@pytest.mark.embedding
+def test_app_save_open(embedded_app, tmp_path: pytest.TempPathFactory):
+    """Test save and open of the Application class."""
+    import System
+    import clr  # noqa: F401
 
-#     # save without a save_as throws an exception
-#     with pytest.raises(System.Exception):
-#         embedded_app.save()
+    # save without a save_as throws an exception
+    with pytest.raises(System.Exception):
+        embedded_app.save()
 
-#     embedded_app.DataModel.Project.Name = "PROJECT 1"
-#     tmpfile = NamedTemporaryFile()
-#     tmpname = tmpfile.name
-#     project_file = os.path.join(tmp_path, f"{tmpname}.mechdat")
-#     embedded_app.save_as(project_file)
-#     embedded_app.new()
-#     embedded_app.open(project_file)
-#     assert embedded_app.DataModel.Project.Name == "PROJECT 1"
-#     embedded_app.DataModel.Project.Name = "PROJECT 2"
-#     embedded_app.save()
-#     embedded_app.new()
-#     embedded_app.open(project_file)
-#     assert embedded_app.DataModel.Project.Name == "PROJECT 2"
-#     embedded_app.new()
-
-
-# @pytest.mark.embedding
-# def test_app_version(embedded_app):
-#     """Test version of the Application class."""
-#     version = embedded_app.version
-#     assert type(version) is int
-#     assert version >= 231
+    embedded_app.DataModel.Project.Name = "PROJECT 1"
+    tmpfile = NamedTemporaryFile()
+    tmpname = tmpfile.name
+    project_file = os.path.join(tmp_path, f"{tmpname}.mechdat")
+    embedded_app.save_as(project_file)
+    embedded_app.new()
+    embedded_app.open(project_file)
+    assert embedded_app.DataModel.Project.Name == "PROJECT 1"
+    embedded_app.DataModel.Project.Name = "PROJECT 2"
+    embedded_app.save()
+    embedded_app.new()
+    embedded_app.open(project_file)
+    assert embedded_app.DataModel.Project.Name == "PROJECT 2"
+    embedded_app.new()
 
 
-# @pytest.mark.embedding
-# def test_nonblock_sleep(embedded_app):
-#     """Test non-blocking sleep."""
-#     t1 = time.time()
-#     utils.sleep(2000)
-#     t2 = time.time()
-#     assert (t2 - t1) >= 2
+@pytest.mark.embedding
+def test_app_version(embedded_app):
+    """Test version of the Application class."""
+    version = embedded_app.version
+    assert type(version) is int
+    assert version >= 231
 
 
-# @pytest.mark.embedding
-# def test_app_getters_notstale(embedded_app):
-#     """The getters of app should be usable after a new().
+@pytest.mark.embedding
+def test_nonblock_sleep(embedded_app):
+    """Test non-blocking sleep."""
+    t1 = time.time()
+    utils.sleep(2000)
+    t2 = time.time()
+    assert (t2 - t1) >= 2
 
-#     The C# objects referred to by ExtAPI, Model, DataModel, and Tree
-#     are reset on each call to app.new(), so storing them in
-#     global variables will be broken.
 
-#     To resolve this, we have to wrap those objects, and ensure
-#     that they properly redirect the calls to the appropriate C#
-#     object after a new()
-#     """
-#     data_model = embedded_app.DataModel
-#     data_model.Project.Name = "a"
-#     model = embedded_app.Model
-#     model.Name = "b"
-#     embedded_app.new()
-#     assert data_model.Project.Name != "a"
-#     assert model.Name != "b"
+@pytest.mark.embedding
+def test_app_getters_notstale(embedded_app):
+    """The getters of app should be usable after a new().
+
+    The C# objects referred to by ExtAPI, Model, DataModel, and Tree
+    are reset on each call to app.new(), so storing them in
+    global variables will be broken.
+
+    To resolve this, we have to wrap those objects, and ensure
+    that they properly redirect the calls to the appropriate C#
+    object after a new()
+    """
+    data_model = embedded_app.DataModel
+    data_model.Project.Name = "a"
+    model = embedded_app.Model
+    model.Name = "b"
+    embedded_app.new()
+    assert data_model.Project.Name != "a"
+    assert model.Name != "b"
 
 
 @pytest.mark.embedding
@@ -162,7 +161,7 @@ def print_stderr(process):
         if not line:
             break
         print(line.rstrip().decode())
-    # time.sleep(0.001)
+    time.sleep(0.001)
 
 
 @pytest.mark.embedding
@@ -232,13 +231,13 @@ def test_normal_appdata(pytestconfig, rootdir):
     assert "ShowTriad value is False" in stdout.decode()
 
 
-# @pytest.mark.embedding
-# def test_rm_lockfile(embedded_app, tmp_path: pytest.TempPathFactory):
-#     """Test lock file is removed on close of embedded application."""
-#     mechdat_path = os.path.join(tmp_path, "test.mechdat")
-#     embedded_app.save(mechdat_path)
-#     embedded_app.close()
+@pytest.mark.embedding
+def test_rm_lockfile(embedded_app, tmp_path: pytest.TempPathFactory):
+    """Test lock file is removed on close of embedded application."""
+    mechdat_path = os.path.join(tmp_path, "test.mechdat")
+    embedded_app.save(mechdat_path)
+    embedded_app.close()
 
-#     lockfile_path = os.path.join(embedded_app.DataModel.Project.ProjectDirectory, ".mech_lock")
-#     # Assert lock file path does not exist
-#     assert not os.path.exists(lockfile_path)
+    lockfile_path = os.path.join(embedded_app.DataModel.Project.ProjectDirectory, ".mech_lock")
+    # Assert lock file path does not exist
+    assert not os.path.exists(lockfile_path)

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -230,3 +230,8 @@ def test_rm_lockfile(embedded_app, tmp_path: pytest.TempPathFactory):
     lockfile_path = os.path.join(embedded_app.DataModel.Project.ProjectDirectory, ".mech_lock")
     # Assert lock file path does not exist
     assert not os.path.exists(lockfile_path)
+
+
+@pytest.mark.embedding
+def test_fail():
+    assert 1 == 2

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -118,15 +118,12 @@ def test_app_getters_notstale(embedded_app):
 @pytest.mark.python_env
 def test_pythonnet_warning(test_env, pytestconfig, rootdir):
     """Test Python.NET warning of the embedded instance using a test-scoped Python environment."""
-    # Install pymechanical
+    # Install pymechanical and pythonnet
     subprocess.check_call(
-        [test_env.python, "-m", "pip", "install", "-e", "."],
+        [test_env.python, "-m", "pip", "install", "-e", ".", "pythonnet"],
         cwd=rootdir,
         env=test_env.env,
     )
-
-    # Install pythonnet
-    subprocess.check_call([test_env.python, "-m", "pip", "install", "pythonnet"], env=test_env.env)
 
     # Run embedded instance in virtual env with pythonnet installed
     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -151,24 +151,20 @@ def test_warning_message(test_env, pytestconfig, rootdir):
     # Assert warning message appears for embedded app
     assert warning, "UserWarning should appear in the output of the script"
 
-    print("done with check warning test")
-
 
 def print_stderr(process):
     while True:
-        # print(datetime.datetime.now())
         line = process.stderr.readline()
         if not line:
             break
         print(line.rstrip().decode())
-    time.sleep(0.001)
+    # time.sleep(0.001)
 
 
 @pytest.mark.embedding
 @pytest.mark.python_env
 def test_private_appdata(pytestconfig, rootdir):
     """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
-    print("starting private appdata test")
     version = pytestconfig.getoption("ansys_version")
     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -116,7 +116,7 @@ def test_app_getters_notstale(embedded_app):
 
 @pytest.mark.embedding
 @pytest.mark.python_env
-def test_warning_message(test_env, pytestconfig, rootdir):
+def test_pythonnet_warning(test_env, pytestconfig, rootdir):
     """Test Python.NET warning of the embedded instance using a test-scoped Python environment."""
     # Install pymechanical
     subprocess.check_call(
@@ -129,14 +129,13 @@ def test_warning_message(test_env, pytestconfig, rootdir):
     )
 
     # Install pythonnet
-    install_pythonnet = subprocess.Popen(
+    subprocess.check_call(
         [test_env.python, "-m", "pip", "install", "pythonnet"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=test_env.env,
         close_fds=True,
     )
-    install_pythonnet.communicate()
 
     # Run embedded instance in virtual env with pythonnet installed
     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """Miscellaneous embedding tests"""
+import datetime
 import os
 import subprocess
 import sys
@@ -147,10 +148,12 @@ def test_warning_message(test_env, pytestconfig, rootdir):
 
 def print_stderr(process):
     while True:
+        print(datetime.datetime.now())
         line = process.stderr.readline()
         if not line:
             break
         print(line.rstrip().decode())
+    time.sleep(0.001)
 
 
 @pytest.mark.embedding

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -145,6 +145,8 @@ def test_warning_message(test_env, pytestconfig, rootdir):
     # Assert warning message appears for embedded app
     assert warning, "UserWarning should appear in the output of the script"
 
+    print("done with check warning test")
+
 
 def print_stderr(process):
     while True:
@@ -160,6 +162,7 @@ def print_stderr(process):
 @pytest.mark.python_env
 def test_private_appdata(pytestconfig, rootdir):
     """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
+    print("starting private appdata test")
     version = pytestconfig.getoption("ansys_version")
     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -154,7 +154,7 @@ def test_private_appdata(pytestconfig, rootdir):
 
     # Set ShowTriad to False
     p1 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "True", "Set"], stdout=subprocess.PIPEl
+        [sys.executable, embedded_py, version, "True", "Set"], stdout=subprocess.PIPE
     )
     p1.communicate()
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -24,8 +24,7 @@
 # import datetime
 import os
 import subprocess
-
-# import sys
+import sys
 from tempfile import NamedTemporaryFile
 import time
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -157,7 +157,7 @@ def test_private_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "True", "Set"], stdout=subprocess.PIPE
     )
     for line in p1.stdout:
-        sys.stdout.write(line)
+        sys.stdout.write(line.decode())
     p1.communicate()
 
     # Check ShowTriad is True for private_appdata embedded sessions
@@ -165,7 +165,7 @@ def test_private_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "True", "Run"], stdout=subprocess.PIPE
     )
     for line in p2.stdout:
-        sys.stdout.write(line)
+        sys.stdout.write(line.decode())
     stdout, stderr = p2.communicate()
 
     assert "ShowTriad value is True" in stdout.decode()
@@ -183,7 +183,7 @@ def test_normal_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "False", "Set"], stdout=subprocess.PIPE
     )
     for line in p1.stdout:
-        sys.stdout.write(line)
+        sys.stdout.write(line.decode())
     p1.communicate()
 
     # Check ShowTriad is False for regular embedded session
@@ -191,7 +191,7 @@ def test_normal_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "False", "Run"], stdout=subprocess.PIPE
     )
     for line in p2.stdout:
-        sys.stdout.write(line)
+        sys.stdout.write(line.decode())
     stdout, stderr = p2.communicate()
 
     # Set ShowTriad back to True for regular embedded session
@@ -199,7 +199,7 @@ def test_normal_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "False", "Reset"], stdout=subprocess.PIPE
     )
     for line in p3.stdout:
-        sys.stdout.write(line)
+        sys.stdout.write(line.decode())
     p3.communicate()
 
     # Assert ShowTriad was set to False for regular embedded session

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -142,9 +142,6 @@ def test_pythonnet_warning(test_env, pytestconfig, rootdir):
     # Assert warning message appears for embedded app
     assert warning, "UserWarning should appear in the output of the script"
 
-    # Kill the check_warning subprocess
-    check_warning.kill()
-
 
 @pytest.mark.embedding
 @pytest.mark.timeout(90)
@@ -156,8 +153,6 @@ def test_private_appdata(pytestconfig, rootdir):
     # Set ShowTriad to False
     p1 = subprocess.Popen(
         [sys.executable, embedded_py, version, "True", "Set"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
     )
     p1.communicate()
 
@@ -165,7 +160,6 @@ def test_private_appdata(pytestconfig, rootdir):
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "True", "Run"],
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
     )
     stdout, stderr = p2.communicate()
 
@@ -182,8 +176,6 @@ def test_normal_appdata(pytestconfig, rootdir):
     # Set ShowTriad to False
     p1 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Set"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
     )
     p1.communicate()
 
@@ -191,15 +183,12 @@ def test_normal_appdata(pytestconfig, rootdir):
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Run"],
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
     )
     stdout, stderr = p2.communicate()
 
     # Set ShowTriad back to True for regular embedded session
     p3 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Reset"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
     )
     p3.communicate()
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -122,18 +122,11 @@ def test_pythonnet_warning(test_env, pytestconfig, rootdir):
     subprocess.check_call(
         [test_env.python, "-m", "pip", "install", "-e", "."],
         cwd=rootdir,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
         env=test_env.env,
     )
 
     # Install pythonnet
-    subprocess.check_call(
-        [test_env.python, "-m", "pip", "install", "pythonnet"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=test_env.env,
-    )
+    subprocess.check_call([test_env.python, "-m", "pip", "install", "pythonnet"], env=test_env.env)
 
     # Run embedded instance in virtual env with pythonnet installed
     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -178,6 +178,7 @@ def test_private_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "True", "Set"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        close_fds=True,
     )
     print_stderr(p1)
     p1.communicate()
@@ -187,6 +188,7 @@ def test_private_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "True", "Run"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        close_fds=True,
     )
     print_stderr(p2)
     stdout, stderr = p2.communicate()
@@ -206,6 +208,7 @@ def test_normal_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "False", "Set"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        close_fds=True,
     )
     print_stderr(p1)
     p1.communicate()
@@ -215,6 +218,7 @@ def test_normal_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "False", "Run"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        close_fds=True,
     )
     print_stderr(p2)
     stdout, stderr = p2.communicate()
@@ -224,6 +228,7 @@ def test_normal_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "False", "Reset"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        close_fds=True,
     )
     print_stderr(p3)
     p3.communicate()

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -114,6 +114,16 @@ def test_app_getters_notstale(embedded_app):
     assert model.Name != "b"
 
 
+def print_stderr(process):
+    while True:
+        print(datetime.datetime.now())
+        line = process.stderr.readline()
+        if not line:
+            break
+        print(line.rstrip().decode())
+    time.sleep(0.001)
+
+
 @pytest.mark.embedding
 @pytest.mark.python_env
 def test_warning_message(test_env, pytestconfig, rootdir):
@@ -136,6 +146,7 @@ def test_warning_message(test_env, pytestconfig, rootdir):
         stderr=subprocess.PIPE,
         env=test_env.env,
     )
+    print_stderr(check_warning)
     stdout, stderr = check_warning.communicate()
 
     # If UserWarning & pythonnet are in the stderr output, set warning to True.
@@ -144,16 +155,6 @@ def test_warning_message(test_env, pytestconfig, rootdir):
 
     # Assert warning message appears for embedded app
     assert warning, "UserWarning should appear in the output of the script"
-
-
-def print_stderr(process):
-    while True:
-        print(datetime.datetime.now())
-        line = process.stderr.readline()
-        if not line:
-            break
-        print(line.rstrip().decode())
-    time.sleep(0.001)
 
 
 @pytest.mark.embedding

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -153,6 +153,8 @@ def test_private_appdata(pytestconfig, rootdir):
     # Set ShowTriad to False
     p1 = subprocess.Popen(
         [sys.executable, embedded_py, version, "True", "Set"],
+        stdout=None,
+        stderr=None,
     )
     p1.communicate()
 
@@ -160,6 +162,7 @@ def test_private_appdata(pytestconfig, rootdir):
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "True", "Run"],
         stdout=subprocess.PIPE,
+        stderr=None,
     )
     stdout, stderr = p2.communicate()
 
@@ -176,6 +179,8 @@ def test_normal_appdata(pytestconfig, rootdir):
     # Set ShowTriad to False
     p1 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Set"],
+        stdout=None,
+        stderr=None,
     )
     p1.communicate()
 
@@ -183,12 +188,15 @@ def test_normal_appdata(pytestconfig, rootdir):
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Run"],
         stdout=subprocess.PIPE,
+        stderr=None,
     )
     stdout, stderr = p2.communicate()
 
     # Set ShowTriad back to True for regular embedded session
     p3 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Reset"],
+        stdout=None,
+        stderr=None,
     )
     p3.communicate()
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """Miscellaneous embedding tests"""
+import logging
 import os
 import subprocess
 import sys
@@ -156,12 +157,24 @@ def test_private_appdata(pytestconfig, rootdir):
     p1 = subprocess.Popen(
         [sys.executable, embedded_py, version, "True", "Set"], stdout=subprocess.PIPE
     )
+    with p1.stdout:
+        for line in iter(p1.stdout.readline, b""):  # b'\n'-separated lines
+            logging.debug("got line from subprocess: %r", line)
+    with p1.stderr:
+        for line in iter(p1.stderr.readline, b""):  # b'\n'-separated lines
+            logging.debug("got line from subprocess: %r", line)
     p1.communicate()
 
     # Check ShowTriad is True for private_appdata embedded sessions
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "True", "Run"], stdout=subprocess.PIPE
     )
+    with p2.stdout:
+        for line in iter(p2.stdout.readline, b""):  # b'\n'-separated lines
+            logging.debug("got line from subprocess: %r", line)
+    with p2.stderr:
+        for line in iter(p2.stderr.readline, b""):  # b'\n'-separated lines
+            logging.debug("got line from subprocess: %r", line)
     stdout, stderr = p2.communicate()
 
     assert "ShowTriad value is True" in stdout.decode()
@@ -178,18 +191,36 @@ def test_normal_appdata(pytestconfig, rootdir):
     p1 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Set"], stdout=subprocess.PIPE
     )
+    with p1.stdout:
+        for line in iter(p1.stdout.readline, b""):  # b'\n'-separated lines
+            logging.debug("got line from subprocess: %r", line)
+    with p1.stderr:
+        for line in iter(p1.stderr.readline, b""):  # b'\n'-separated lines
+            logging.debug("got line from subprocess: %r", line)
     p1.communicate()
 
     # Check ShowTriad is False for regular embedded session
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Run"], stdout=subprocess.PIPE
     )
+    with p2.stdout:
+        for line in iter(p2.stdout.readline, b""):  # b'\n'-separated lines
+            logging.debug("got line from subprocess: %r", line)
+    with p2.stderr:
+        for line in iter(p2.stderr.readline, b""):  # b'\n'-separated lines
+            logging.debug("got line from subprocess: %r", line)
     stdout, stderr = p2.communicate()
 
     # Set ShowTriad back to True for regular embedded session
     p3 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Reset"], stdout=subprocess.PIPE
     )
+    with p3.stdout:
+        for line in iter(p3.stdout.readline, b""):  # b'\n'-separated lines
+            logging.debug("got line from subprocess: %r", line)
+    with p3.stderr:
+        for line in iter(p3.stderr.readline, b""):  # b'\n'-separated lines
+            logging.debug("got line from subprocess: %r", line)
     p3.communicate()
 
     # Assert ShowTriad was set to False for regular embedded session

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -118,7 +118,6 @@ def test_app_getters_notstale(embedded_app):
 @pytest.mark.python_env
 def test_warning_message(test_env, pytestconfig, rootdir):
     """Test Python.NET warning of the embedded instance using a test-scoped Python environment."""
-
     # Install pymechanical
     subprocess.check_call(
         [test_env.python, "-m", "pip", "install", "-e", "."],
@@ -156,8 +155,6 @@ def test_warning_message(test_env, pytestconfig, rootdir):
     # Assert warning message appears for embedded app
     assert warning, "UserWarning should appear in the output of the script"
 
-    print("done with check warning")
-
 
 # def print_stderr(process):
 #     while True:
@@ -171,7 +168,6 @@ def test_warning_message(test_env, pytestconfig, rootdir):
 @pytest.mark.embedding
 def test_private_appdata(pytestconfig, rootdir):
     """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
-    print("starting private_appdata")
     version = pytestconfig.getoption("ansys_version")
     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
 
@@ -196,8 +192,6 @@ def test_private_appdata(pytestconfig, rootdir):
     stdout, stderr = p2.communicate()
 
     assert "ShowTriad value is True" in stdout.decode()
-
-    print("done with private_appdata")
 
 
 @pytest.mark.embedding

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -21,7 +21,6 @@
 # SOFTWARE.
 
 """Miscellaneous embedding tests"""
-import logging
 import os
 import subprocess
 import sys
@@ -155,26 +154,14 @@ def test_private_appdata(pytestconfig, rootdir):
 
     # Set ShowTriad to False
     p1 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "True", "Set"], stdout=subprocess.PIPE
+        [sys.executable, embedded_py, version, "True", "Set"], stdout=subprocess.PIPEl
     )
-    with p1.stdout:
-        for line in iter(p1.stdout.readline, b""):  # b'\n'-separated lines
-            logging.debug("got line from subprocess: %r", line)
-    with p1.stderr:
-        for line in iter(p1.stderr.readline, b""):  # b'\n'-separated lines
-            logging.debug("got line from subprocess: %r", line)
     p1.communicate()
 
     # Check ShowTriad is True for private_appdata embedded sessions
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "True", "Run"], stdout=subprocess.PIPE
     )
-    with p2.stdout:
-        for line in iter(p2.stdout.readline, b""):  # b'\n'-separated lines
-            logging.debug("got line from subprocess: %r", line)
-    with p2.stderr:
-        for line in iter(p2.stderr.readline, b""):  # b'\n'-separated lines
-            logging.debug("got line from subprocess: %r", line)
     stdout, stderr = p2.communicate()
 
     assert "ShowTriad value is True" in stdout.decode()
@@ -191,36 +178,18 @@ def test_normal_appdata(pytestconfig, rootdir):
     p1 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Set"], stdout=subprocess.PIPE
     )
-    with p1.stdout:
-        for line in iter(p1.stdout.readline, b""):  # b'\n'-separated lines
-            logging.debug("got line from subprocess: %r", line)
-    with p1.stderr:
-        for line in iter(p1.stderr.readline, b""):  # b'\n'-separated lines
-            logging.debug("got line from subprocess: %r", line)
     p1.communicate()
 
     # Check ShowTriad is False for regular embedded session
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Run"], stdout=subprocess.PIPE
     )
-    with p2.stdout:
-        for line in iter(p2.stdout.readline, b""):  # b'\n'-separated lines
-            logging.debug("got line from subprocess: %r", line)
-    with p2.stderr:
-        for line in iter(p2.stderr.readline, b""):  # b'\n'-separated lines
-            logging.debug("got line from subprocess: %r", line)
     stdout, stderr = p2.communicate()
 
     # Set ShowTriad back to True for regular embedded session
     p3 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Reset"], stdout=subprocess.PIPE
     )
-    with p3.stdout:
-        for line in iter(p3.stdout.readline, b""):  # b'\n'-separated lines
-            logging.debug("got line from subprocess: %r", line)
-    with p3.stderr:
-        for line in iter(p3.stderr.readline, b""):  # b'\n'-separated lines
-            logging.debug("got line from subprocess: %r", line)
     p3.communicate()
 
     # Assert ShowTriad was set to False for regular embedded session

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -23,8 +23,8 @@
 """Miscellaneous embedding tests"""
 # import datetime
 import os
+import subprocess
 
-# import subprocess
 # import sys
 from tempfile import NamedTemporaryFile
 import time
@@ -115,47 +115,47 @@ def test_app_getters_notstale(embedded_app):
     assert model.Name != "b"
 
 
-# @pytest.mark.embedding
-# @pytest.mark.python_env
-# def test_warning_message(test_env, pytestconfig, rootdir):
-#     """Test Python.NET warning of the embedded instance using a test-scoped Python environment."""
+@pytest.mark.embedding
+@pytest.mark.python_env
+def test_warning_message(test_env, pytestconfig, rootdir):
+    """Test Python.NET warning of the embedded instance using a test-scoped Python environment."""
 
-#     # Install pymechanical
-#     subprocess.check_call(
-#         [test_env.python, "-m", "pip", "install", "-e", "."],
-#         cwd=rootdir,
-#         stdout=subprocess.PIPE,
-#         stderr=subprocess.PIPE,
-#         env=test_env.env,
-#         close_fds=True,
-#     )
+    # Install pymechanical
+    subprocess.check_call(
+        [test_env.python, "-m", "pip", "install", "-e", "."],
+        cwd=rootdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=test_env.env,
+        close_fds=True,
+    )
 
-#     # Install pythonnet
-#     install_pythonnet = subprocess.Popen(
-#         [test_env.python, "-m", "pip", "install", "pythonnet"],
-#         stdout=subprocess.PIPE,
-#         stderr=subprocess.PIPE,
-#         env=test_env.env,
-#         close_fds=True,
-#     )
-#     install_pythonnet.communicate()
+    # Install pythonnet
+    install_pythonnet = subprocess.Popen(
+        [test_env.python, "-m", "pip", "install", "pythonnet"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=test_env.env,
+        close_fds=True,
+    )
+    install_pythonnet.communicate()
 
-#     # Run embedded instance in virtual env with pythonnet installed
-#     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
-#     check_warning = subprocess.Popen(
-#         [test_env.python, embedded_py, pytestconfig.getoption("ansys_version")],
-#         stderr=subprocess.PIPE,
-#         env=test_env.env,
-#         close_fds=True,
-#     )
-#     stdout, stderr = check_warning.communicate()
+    # Run embedded instance in virtual env with pythonnet installed
+    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
+    check_warning = subprocess.Popen(
+        [test_env.python, embedded_py, pytestconfig.getoption("ansys_version")],
+        stderr=subprocess.PIPE,
+        env=test_env.env,
+        close_fds=True,
+    )
+    stdout, stderr = check_warning.communicate()
 
-#     # If UserWarning & pythonnet are in the stderr output, set warning to True.
-#     # Otherwise, set warning to False
-#     warning = True if "UserWarning" and "pythonnet" in stderr.decode() else False
+    # If UserWarning & pythonnet are in the stderr output, set warning to True.
+    # Otherwise, set warning to False
+    warning = True if "UserWarning" and "pythonnet" in stderr.decode() else False
 
-#     # Assert warning message appears for embedded app
-#     assert warning, "UserWarning should appear in the output of the script"
+    # Assert warning message appears for embedded app
+    assert warning, "UserWarning should appear in the output of the script"
 
 
 # def print_stderr(process):

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -25,93 +25,94 @@
 import os
 import subprocess
 import sys
-from tempfile import NamedTemporaryFile
-import time
 
 import pytest
 
-import ansys.mechanical.core.embedding.utils as utils
+# from tempfile import NamedTemporaryFile
+# import time
 
 
-@pytest.mark.embedding
-def test_app_repr(embedded_app):
-    """Test repr of the Application class."""
-    app_repr_lines = repr(embedded_app).splitlines()
-    assert app_repr_lines[0].startswith("Ansys Mechanical")
-    assert app_repr_lines[1].startswith("Product Version")
-    assert app_repr_lines[2].startswith("Software build date:")
+# import ansys.mechanical.core.embedding.utils as utils
+
+# @pytest.mark.embedding
+# def test_app_repr(embedded_app):
+#     """Test repr of the Application class."""
+#     app_repr_lines = repr(embedded_app).splitlines()
+#     assert app_repr_lines[0].startswith("Ansys Mechanical")
+#     assert app_repr_lines[1].startswith("Product Version")
+#     assert app_repr_lines[2].startswith("Software build date:")
 
 
-@pytest.mark.embedding
-@pytest.mark.minimum_version(241)
-def test_deprecation_warning(embedded_app):
-    struct = embedded_app.Model.AddStaticStructuralAnalysis()
-    with pytest.warns(UserWarning):
-        struct.SystemID
+# @pytest.mark.embedding
+# @pytest.mark.minimum_version(241)
+# def test_deprecation_warning(embedded_app):
+#     struct = embedded_app.Model.AddStaticStructuralAnalysis()
+#     with pytest.warns(UserWarning):
+#         struct.SystemID
 
 
-@pytest.mark.embedding
-def test_app_save_open(embedded_app, tmp_path: pytest.TempPathFactory):
-    """Test save and open of the Application class."""
-    import System
-    import clr  # noqa: F401
+# @pytest.mark.embedding
+# def test_app_save_open(embedded_app, tmp_path: pytest.TempPathFactory):
+#     """Test save and open of the Application class."""
+#     import System
+#     import clr  # noqa: F401
 
-    # save without a save_as throws an exception
-    with pytest.raises(System.Exception):
-        embedded_app.save()
+#     # save without a save_as throws an exception
+#     with pytest.raises(System.Exception):
+#         embedded_app.save()
 
-    embedded_app.DataModel.Project.Name = "PROJECT 1"
-    tmpfile = NamedTemporaryFile()
-    tmpname = tmpfile.name
-    project_file = os.path.join(tmp_path, f"{tmpname}.mechdat")
-    embedded_app.save_as(project_file)
-    embedded_app.new()
-    embedded_app.open(project_file)
-    assert embedded_app.DataModel.Project.Name == "PROJECT 1"
-    embedded_app.DataModel.Project.Name = "PROJECT 2"
-    embedded_app.save()
-    embedded_app.new()
-    embedded_app.open(project_file)
-    assert embedded_app.DataModel.Project.Name == "PROJECT 2"
-    embedded_app.new()
-
-
-@pytest.mark.embedding
-def test_app_version(embedded_app):
-    """Test version of the Application class."""
-    version = embedded_app.version
-    assert type(version) is int
-    assert version >= 231
+#     embedded_app.DataModel.Project.Name = "PROJECT 1"
+#     tmpfile = NamedTemporaryFile()
+#     tmpname = tmpfile.name
+#     project_file = os.path.join(tmp_path, f"{tmpname}.mechdat")
+#     embedded_app.save_as(project_file)
+#     embedded_app.new()
+#     embedded_app.open(project_file)
+#     assert embedded_app.DataModel.Project.Name == "PROJECT 1"
+#     embedded_app.DataModel.Project.Name = "PROJECT 2"
+#     embedded_app.save()
+#     embedded_app.new()
+#     embedded_app.open(project_file)
+#     assert embedded_app.DataModel.Project.Name == "PROJECT 2"
+#     embedded_app.new()
 
 
-@pytest.mark.embedding
-def test_nonblock_sleep(embedded_app):
-    """Test non-blocking sleep."""
-    t1 = time.time()
-    utils.sleep(2000)
-    t2 = time.time()
-    assert (t2 - t1) >= 2
+# @pytest.mark.embedding
+# def test_app_version(embedded_app):
+#     """Test version of the Application class."""
+#     version = embedded_app.version
+#     assert type(version) is int
+#     assert version >= 231
 
 
-@pytest.mark.embedding
-def test_app_getters_notstale(embedded_app):
-    """The getters of app should be usable after a new().
+# @pytest.mark.embedding
+# def test_nonblock_sleep(embedded_app):
+#     """Test non-blocking sleep."""
+#     t1 = time.time()
+#     utils.sleep(2000)
+#     t2 = time.time()
+#     assert (t2 - t1) >= 2
 
-    The C# objects referred to by ExtAPI, Model, DataModel, and Tree
-    are reset on each call to app.new(), so storing them in
-    global variables will be broken.
 
-    To resolve this, we have to wrap those objects, and ensure
-    that they properly redirect the calls to the appropriate C#
-    object after a new()
-    """
-    data_model = embedded_app.DataModel
-    data_model.Project.Name = "a"
-    model = embedded_app.Model
-    model.Name = "b"
-    embedded_app.new()
-    assert data_model.Project.Name != "a"
-    assert model.Name != "b"
+# @pytest.mark.embedding
+# def test_app_getters_notstale(embedded_app):
+#     """The getters of app should be usable after a new().
+
+#     The C# objects referred to by ExtAPI, Model, DataModel, and Tree
+#     are reset on each call to app.new(), so storing them in
+#     global variables will be broken.
+
+#     To resolve this, we have to wrap those objects, and ensure
+#     that they properly redirect the calls to the appropriate C#
+#     object after a new()
+#     """
+#     data_model = embedded_app.DataModel
+#     data_model.Project.Name = "a"
+#     model = embedded_app.Model
+#     model.Name = "b"
+#     embedded_app.new()
+#     assert data_model.Project.Name != "a"
+#     assert model.Name != "b"
 
 
 @pytest.mark.embedding
@@ -127,7 +128,13 @@ def test_warning_message(test_env, pytestconfig, rootdir):
     )
 
     # Install pythonnet
-    subprocess.check_call([test_env.python, "-m", "pip", "install", "pythonnet"], env=test_env.env)
+    install_pythonnet = subprocess.Popen(
+        [test_env.python, "-m", "pip", "install", "pythonnet"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=test_env.env,
+    )
+    install_pythonnet.communicate()
 
     # Run embedded instance in virtual env with pythonnet installed
     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
@@ -225,13 +232,13 @@ def test_normal_appdata(pytestconfig, rootdir):
     assert "ShowTriad value is False" in stdout.decode()
 
 
-@pytest.mark.embedding
-def test_rm_lockfile(embedded_app, tmp_path: pytest.TempPathFactory):
-    """Test lock file is removed on close of embedded application."""
-    mechdat_path = os.path.join(tmp_path, "test.mechdat")
-    embedded_app.save(mechdat_path)
-    embedded_app.close()
+# @pytest.mark.embedding
+# def test_rm_lockfile(embedded_app, tmp_path: pytest.TempPathFactory):
+#     """Test lock file is removed on close of embedded application."""
+#     mechdat_path = os.path.join(tmp_path, "test.mechdat")
+#     embedded_app.save(mechdat_path)
+#     embedded_app.close()
 
-    lockfile_path = os.path.join(embedded_app.DataModel.Project.ProjectDirectory, ".mech_lock")
-    # Assert lock file path does not exist
-    assert not os.path.exists(lockfile_path)
+#     lockfile_path = os.path.join(embedded_app.DataModel.Project.ProjectDirectory, ".mech_lock")
+#     # Assert lock file path does not exist
+#     assert not os.path.exists(lockfile_path)

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -156,12 +156,16 @@ def test_private_appdata(pytestconfig, rootdir):
     p1 = subprocess.Popen(
         [sys.executable, embedded_py, version, "True", "Set"], stdout=subprocess.PIPE
     )
+    for line in p1.stdout:
+        sys.stdout.write(line)
     p1.communicate()
 
     # Check ShowTriad is True for private_appdata embedded sessions
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "True", "Run"], stdout=subprocess.PIPE
     )
+    for line in p2.stdout:
+        sys.stdout.write(line)
     stdout, stderr = p2.communicate()
 
     assert "ShowTriad value is True" in stdout.decode()
@@ -178,18 +182,24 @@ def test_normal_appdata(pytestconfig, rootdir):
     p1 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Set"], stdout=subprocess.PIPE
     )
+    for line in p1.stdout:
+        sys.stdout.write(line)
     p1.communicate()
 
     # Check ShowTriad is False for regular embedded session
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Run"], stdout=subprocess.PIPE
     )
+    for line in p2.stdout:
+        sys.stdout.write(line)
     stdout, stderr = p2.communicate()
 
     # Set ShowTriad back to True for regular embedded session
     p3 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Reset"], stdout=subprocess.PIPE
     )
+    for line in p3.stdout:
+        sys.stdout.write(line)
     p3.communicate()
 
     # Assert ShowTriad was set to False for regular embedded session

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -23,8 +23,9 @@
 """Miscellaneous embedding tests"""
 # import datetime
 import os
-import subprocess
-import sys
+
+# import subprocess
+# import sys
 from tempfile import NamedTemporaryFile
 import time
 
@@ -114,127 +115,127 @@ def test_app_getters_notstale(embedded_app):
     assert model.Name != "b"
 
 
-@pytest.mark.embedding
-@pytest.mark.python_env
-def test_warning_message(test_env, pytestconfig, rootdir):
-    """Test Python.NET warning of the embedded instance using a test-scoped Python environment."""
+# @pytest.mark.embedding
+# @pytest.mark.python_env
+# def test_warning_message(test_env, pytestconfig, rootdir):
+#     """Test Python.NET warning of the embedded instance using a test-scoped Python environment."""
 
-    # Install pymechanical
-    subprocess.check_call(
-        [test_env.python, "-m", "pip", "install", "-e", "."],
-        cwd=rootdir,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=test_env.env,
-        close_fds=True,
-    )
+#     # Install pymechanical
+#     subprocess.check_call(
+#         [test_env.python, "-m", "pip", "install", "-e", "."],
+#         cwd=rootdir,
+#         stdout=subprocess.PIPE,
+#         stderr=subprocess.PIPE,
+#         env=test_env.env,
+#         close_fds=True,
+#     )
 
-    # Install pythonnet
-    install_pythonnet = subprocess.Popen(
-        [test_env.python, "-m", "pip", "install", "pythonnet"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=test_env.env,
-        close_fds=True,
-    )
-    install_pythonnet.communicate()
+#     # Install pythonnet
+#     install_pythonnet = subprocess.Popen(
+#         [test_env.python, "-m", "pip", "install", "pythonnet"],
+#         stdout=subprocess.PIPE,
+#         stderr=subprocess.PIPE,
+#         env=test_env.env,
+#         close_fds=True,
+#     )
+#     install_pythonnet.communicate()
 
-    # Run embedded instance in virtual env with pythonnet installed
-    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
-    check_warning = subprocess.Popen(
-        [test_env.python, embedded_py, pytestconfig.getoption("ansys_version")],
-        stderr=subprocess.PIPE,
-        env=test_env.env,
-        close_fds=True,
-    )
-    stdout, stderr = check_warning.communicate()
+#     # Run embedded instance in virtual env with pythonnet installed
+#     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
+#     check_warning = subprocess.Popen(
+#         [test_env.python, embedded_py, pytestconfig.getoption("ansys_version")],
+#         stderr=subprocess.PIPE,
+#         env=test_env.env,
+#         close_fds=True,
+#     )
+#     stdout, stderr = check_warning.communicate()
 
-    # If UserWarning & pythonnet are in the stderr output, set warning to True.
-    # Otherwise, set warning to False
-    warning = True if "UserWarning" and "pythonnet" in stderr.decode() else False
+#     # If UserWarning & pythonnet are in the stderr output, set warning to True.
+#     # Otherwise, set warning to False
+#     warning = True if "UserWarning" and "pythonnet" in stderr.decode() else False
 
-    # Assert warning message appears for embedded app
-    assert warning, "UserWarning should appear in the output of the script"
-
-
-def print_stderr(process):
-    while True:
-        line = process.stderr.readline()
-        if not line:
-            break
-        print(line.rstrip().decode())
-    # time.sleep(0.001)
+#     # Assert warning message appears for embedded app
+#     assert warning, "UserWarning should appear in the output of the script"
 
 
-@pytest.mark.embedding
-@pytest.mark.python_env
-def test_private_appdata(pytestconfig, rootdir):
-    """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
-    version = pytestconfig.getoption("ansys_version")
-    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
-
-    # Set ShowTriad to False
-    p1 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "True", "Set"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        close_fds=True,
-    )
-    print_stderr(p1)
-    p1.communicate()
-
-    # Check ShowTriad is True for private_appdata embedded sessions
-    p2 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "True", "Run"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        close_fds=True,
-    )
-    print_stderr(p2)
-    stdout, stderr = p2.communicate()
-
-    assert "ShowTriad value is True" in stdout.decode()
+# def print_stderr(process):
+#     while True:
+#         line = process.stderr.readline()
+#         if not line:
+#             break
+#         print(line.rstrip().decode())
+#     # time.sleep(0.001)
 
 
-@pytest.mark.embedding
-@pytest.mark.python_env
-def test_normal_appdata(pytestconfig, rootdir):
-    """Test embedded instance saves ShowTriad value using a test-scoped Python environment."""
-    version = pytestconfig.getoption("ansys_version")
-    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
+# @pytest.mark.embedding
+# @pytest.mark.python_env
+# def test_private_appdata(pytestconfig, rootdir):
+#     """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
+#     version = pytestconfig.getoption("ansys_version")
+#     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
 
-    # Set ShowTriad to False
-    p1 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "False", "Set"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        close_fds=True,
-    )
-    print_stderr(p1)
-    p1.communicate()
+#     # Set ShowTriad to False
+#     p1 = subprocess.Popen(
+#         [sys.executable, embedded_py, version, "True", "Set"],
+#         stdout=subprocess.PIPE,
+#         stderr=subprocess.PIPE,
+#         close_fds=True,
+#     )
+#     print_stderr(p1)
+#     p1.communicate()
 
-    # Check ShowTriad is False for regular embedded session
-    p2 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "False", "Run"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        close_fds=True,
-    )
-    print_stderr(p2)
-    stdout, stderr = p2.communicate()
+#     # Check ShowTriad is True for private_appdata embedded sessions
+#     p2 = subprocess.Popen(
+#         [sys.executable, embedded_py, version, "True", "Run"],
+#         stdout=subprocess.PIPE,
+#         stderr=subprocess.PIPE,
+#         close_fds=True,
+#     )
+#     print_stderr(p2)
+#     stdout, stderr = p2.communicate()
 
-    # Set ShowTriad back to True for regular embedded session
-    p3 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "False", "Reset"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        close_fds=True,
-    )
-    print_stderr(p3)
-    p3.communicate()
+#     assert "ShowTriad value is True" in stdout.decode()
 
-    # Assert ShowTriad was set to False for regular embedded session
-    assert "ShowTriad value is False" in stdout.decode()
+
+# @pytest.mark.embedding
+# @pytest.mark.python_env
+# def test_normal_appdata(pytestconfig, rootdir):
+#     """Test embedded instance saves ShowTriad value using a test-scoped Python environment."""
+#     version = pytestconfig.getoption("ansys_version")
+#     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
+
+#     # Set ShowTriad to False
+#     p1 = subprocess.Popen(
+#         [sys.executable, embedded_py, version, "False", "Set"],
+#         stdout=subprocess.PIPE,
+#         stderr=subprocess.PIPE,
+#         close_fds=True,
+#     )
+#     print_stderr(p1)
+#     p1.communicate()
+
+#     # Check ShowTriad is False for regular embedded session
+#     p2 = subprocess.Popen(
+#         [sys.executable, embedded_py, version, "False", "Run"],
+#         stdout=subprocess.PIPE,
+#         stderr=subprocess.PIPE,
+#         close_fds=True,
+#     )
+#     print_stderr(p2)
+#     stdout, stderr = p2.communicate()
+
+#     # Set ShowTriad back to True for regular embedded session
+#     p3 = subprocess.Popen(
+#         [sys.executable, embedded_py, version, "False", "Reset"],
+#         stdout=subprocess.PIPE,
+#         stderr=subprocess.PIPE,
+#         close_fds=True,
+#     )
+#     print_stderr(p3)
+#     p3.communicate()
+
+#     # Assert ShowTriad was set to False for regular embedded session
+#     assert "ShowTriad value is False" in stdout.decode()
 
 
 @pytest.mark.embedding

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -145,6 +145,14 @@ def test_warning_message(test_env, pytestconfig, rootdir):
     assert warning, "UserWarning should appear in the output of the script"
 
 
+def print_stderr(process):
+    while True:
+        line = process.stderr.readline()
+        if not line:
+            break
+        print(line.rstrip().decode())
+
+
 @pytest.mark.embedding
 @pytest.mark.python_env
 def test_private_appdata(pytestconfig, rootdir):
@@ -154,18 +162,20 @@ def test_private_appdata(pytestconfig, rootdir):
 
     # Set ShowTriad to False
     p1 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "True", "Set"], stdout=subprocess.PIPE
+        [sys.executable, embedded_py, version, "True", "Set"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    for line in p1.stdout:
-        sys.stdout.write(line.decode())
+    print_stderr(p1)
     p1.communicate()
 
     # Check ShowTriad is True for private_appdata embedded sessions
     p2 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "True", "Run"], stdout=subprocess.PIPE
+        [sys.executable, embedded_py, version, "True", "Run"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    for line in p2.stdout:
-        sys.stdout.write(line.decode())
+    print_stderr(p2)
     stdout, stderr = p2.communicate()
 
     assert "ShowTriad value is True" in stdout.decode()
@@ -180,26 +190,29 @@ def test_normal_appdata(pytestconfig, rootdir):
 
     # Set ShowTriad to False
     p1 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "False", "Set"], stdout=subprocess.PIPE
+        [sys.executable, embedded_py, version, "False", "Set"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    for line in p1.stdout:
-        sys.stdout.write(line.decode())
+    print_stderr(p1)
     p1.communicate()
 
     # Check ShowTriad is False for regular embedded session
     p2 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "False", "Run"], stdout=subprocess.PIPE
+        [sys.executable, embedded_py, version, "False", "Run"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    for line in p2.stdout:
-        sys.stdout.write(line.decode())
+    print_stderr(p2)
     stdout, stderr = p2.communicate()
 
     # Set ShowTriad back to True for regular embedded session
     p3 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "False", "Reset"], stdout=subprocess.PIPE
+        [sys.executable, embedded_py, version, "False", "Reset"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    for line in p3.stdout:
-        sys.stdout.write(line.decode())
+    print_stderr(p3)
     p3.communicate()
 
     # Assert ShowTriad was set to False for regular embedded session

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -116,6 +116,7 @@ def test_app_getters_notstale(embedded_app):
 
 @pytest.mark.embedding
 @pytest.mark.python_env
+@pytest.mark.timeout(60)
 def test_pythonnet_warning(test_env, pytestconfig, rootdir):
     """Test Python.NET warning of the embedded instance using a test-scoped Python environment."""
     # Install pymechanical and pythonnet
@@ -143,6 +144,7 @@ def test_pythonnet_warning(test_env, pytestconfig, rootdir):
 
 
 @pytest.mark.embedding
+@pytest.mark.timeout(90)
 def test_private_appdata(pytestconfig, rootdir):
     """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
     version = pytestconfig.getoption("ansys_version")

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -200,44 +200,44 @@ def test_private_appdata(pytestconfig, rootdir):
     print("done with private_appdata")
 
 
-# @pytest.mark.embedding
-# def test_normal_appdata(pytestconfig, rootdir):
-#     """Test embedded instance saves ShowTriad value using a test-scoped Python environment."""
-#     version = pytestconfig.getoption("ansys_version")
-#     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
+@pytest.mark.embedding
+def test_normal_appdata(pytestconfig, rootdir):
+    """Test embedded instance saves ShowTriad value using a test-scoped Python environment."""
+    version = pytestconfig.getoption("ansys_version")
+    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
 
-#     # Set ShowTriad to False
-#     p1 = subprocess.Popen(
-#         [sys.executable, embedded_py, version, "False", "Set"],
-#         stdout=subprocess.PIPE,
-#         stderr=subprocess.PIPE,
-#         close_fds=True,
-#     )
-#     print_stderr(p1)
-#     p1.communicate()
+    # Set ShowTriad to False
+    p1 = subprocess.Popen(
+        [sys.executable, embedded_py, version, "False", "Set"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True,
+    )
+    # print_stderr(p1)
+    p1.communicate()
 
-#     # Check ShowTriad is False for regular embedded session
-#     p2 = subprocess.Popen(
-#         [sys.executable, embedded_py, version, "False", "Run"],
-#         stdout=subprocess.PIPE,
-#         stderr=subprocess.PIPE,
-#         close_fds=True,
-#     )
-#     print_stderr(p2)
-#     stdout, stderr = p2.communicate()
+    # Check ShowTriad is False for regular embedded session
+    p2 = subprocess.Popen(
+        [sys.executable, embedded_py, version, "False", "Run"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True,
+    )
+    # print_stderr(p2)
+    stdout, stderr = p2.communicate()
 
-#     # Set ShowTriad back to True for regular embedded session
-#     p3 = subprocess.Popen(
-#         [sys.executable, embedded_py, version, "False", "Reset"],
-#         stdout=subprocess.PIPE,
-#         stderr=subprocess.PIPE,
-#         close_fds=True,
-#     )
-#     print_stderr(p3)
-#     p3.communicate()
+    # Set ShowTriad back to True for regular embedded session
+    p3 = subprocess.Popen(
+        [sys.executable, embedded_py, version, "False", "Reset"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True,
+    )
+    # print_stderr(p3)
+    p3.communicate()
 
-#     # Assert ShowTriad was set to False for regular embedded session
-#     assert "ShowTriad value is False" in stdout.decode()
+    # Assert ShowTriad was set to False for regular embedded session
+    assert "ShowTriad value is False" in stdout.decode()
 
 
 @pytest.mark.embedding

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -167,34 +167,34 @@ def test_warning_message(test_env, pytestconfig, rootdir):
 #     # time.sleep(0.001)
 
 
-# @pytest.mark.embedding
-# @pytest.mark.python_env
-# def test_private_appdata(pytestconfig, rootdir):
-#     """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
-#     version = pytestconfig.getoption("ansys_version")
-#     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
+@pytest.mark.embedding
+@pytest.mark.python_env
+def test_private_appdata(pytestconfig, rootdir):
+    """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
+    version = pytestconfig.getoption("ansys_version")
+    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
 
-#     # Set ShowTriad to False
-#     p1 = subprocess.Popen(
-#         [sys.executable, embedded_py, version, "True", "Set"],
-#         stdout=subprocess.PIPE,
-#         stderr=subprocess.PIPE,
-#         close_fds=True,
-#     )
-#     print_stderr(p1)
-#     p1.communicate()
+    # Set ShowTriad to False
+    p1 = subprocess.Popen(
+        [sys.executable, embedded_py, version, "True", "Set"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True,
+    )
+    # print_stderr(p1)
+    p1.communicate()
 
-#     # Check ShowTriad is True for private_appdata embedded sessions
-#     p2 = subprocess.Popen(
-#         [sys.executable, embedded_py, version, "True", "Run"],
-#         stdout=subprocess.PIPE,
-#         stderr=subprocess.PIPE,
-#         close_fds=True,
-#     )
-#     print_stderr(p2)
-#     stdout, stderr = p2.communicate()
+    # Check ShowTriad is True for private_appdata embedded sessions
+    p2 = subprocess.Popen(
+        [sys.executable, embedded_py, version, "True", "Run"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True,
+    )
+    # print_stderr(p2)
+    stdout, stderr = p2.communicate()
 
-#     assert "ShowTriad value is True" in stdout.decode()
+    assert "ShowTriad value is True" in stdout.decode()
 
 
 # @pytest.mark.embedding

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -230,8 +230,3 @@ def test_rm_lockfile(embedded_app, tmp_path: pytest.TempPathFactory):
     lockfile_path = os.path.join(embedded_app.DataModel.Project.ProjectDirectory, ".mech_lock")
     # Assert lock file path does not exist
     assert not os.path.exists(lockfile_path)
-
-
-@pytest.mark.embedding
-def test_fail():
-    assert 1 == 2

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -123,7 +123,10 @@ def test_warning_message(test_env, pytestconfig, rootdir):
     subprocess.check_call(
         [test_env.python, "-m", "pip", "install", "-e", "."],
         cwd=rootdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         env=test_env.env,
+        close_fds=True,
     )
 
     # Install pythonnet
@@ -132,6 +135,7 @@ def test_warning_message(test_env, pytestconfig, rootdir):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=test_env.env,
+        close_fds=True,
     )
     install_pythonnet.communicate()
 
@@ -141,6 +145,7 @@ def test_warning_message(test_env, pytestconfig, rootdir):
         [test_env.python, embedded_py, pytestconfig.getoption("ansys_version")],
         stderr=subprocess.PIPE,
         env=test_env.env,
+        close_fds=True,
     )
     stdout, stderr = check_warning.communicate()
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -116,7 +116,7 @@ def test_app_getters_notstale(embedded_app):
 
 @pytest.mark.embedding
 @pytest.mark.python_env
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(90)
 def test_pythonnet_warning(test_env, pytestconfig, rootdir):
     """Test Python.NET warning of the embedded instance using a test-scoped Python environment."""
     # Install pymechanical and pythonnet
@@ -155,7 +155,6 @@ def test_private_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "True", "Set"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        close_fds=True,
     )
     p1.communicate()
 
@@ -164,7 +163,6 @@ def test_private_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "True", "Run"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        close_fds=True,
     )
     stdout, stderr = p2.communicate()
 
@@ -172,6 +170,7 @@ def test_private_appdata(pytestconfig, rootdir):
 
 
 @pytest.mark.embedding
+@pytest.mark.timeout(90)
 def test_normal_appdata(pytestconfig, rootdir):
     """Test embedded instance saves ShowTriad value using a test-scoped Python environment."""
     version = pytestconfig.getoption("ansys_version")
@@ -182,7 +181,6 @@ def test_normal_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "False", "Set"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        close_fds=True,
     )
     p1.communicate()
 
@@ -191,7 +189,6 @@ def test_normal_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "False", "Run"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        close_fds=True,
     )
     stdout, stderr = p2.communicate()
 
@@ -200,7 +197,6 @@ def test_normal_appdata(pytestconfig, rootdir):
         [sys.executable, embedded_py, version, "False", "Reset"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        close_fds=True,
     )
     p3.communicate()
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -125,7 +125,6 @@ def test_pythonnet_warning(test_env, pytestconfig, rootdir):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=test_env.env,
-        close_fds=True,
     )
 
     # Install pythonnet
@@ -134,7 +133,6 @@ def test_pythonnet_warning(test_env, pytestconfig, rootdir):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=test_env.env,
-        close_fds=True,
     )
 
     # Run embedded instance in virtual env with pythonnet installed
@@ -143,7 +141,6 @@ def test_pythonnet_warning(test_env, pytestconfig, rootdir):
         [test_env.python, embedded_py, pytestconfig.getoption("ansys_version")],
         stderr=subprocess.PIPE,
         env=test_env.env,
-        close_fds=True,
     )
     stdout, stderr = check_warning.communicate()
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -156,6 +156,8 @@ def test_warning_message(test_env, pytestconfig, rootdir):
     # Assert warning message appears for embedded app
     assert warning, "UserWarning should appear in the output of the script"
 
+    print("done with check warning")
+
 
 # def print_stderr(process):
 #     while True:
@@ -167,9 +169,9 @@ def test_warning_message(test_env, pytestconfig, rootdir):
 
 
 @pytest.mark.embedding
-@pytest.mark.python_env
 def test_private_appdata(pytestconfig, rootdir):
     """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
+    print("starting private_appdata")
     version = pytestconfig.getoption("ansys_version")
     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
 
@@ -195,9 +197,10 @@ def test_private_appdata(pytestconfig, rootdir):
 
     assert "ShowTriad value is True" in stdout.decode()
 
+    print("done with private_appdata")
+
 
 # @pytest.mark.embedding
-# @pytest.mark.python_env
 # def test_normal_appdata(pytestconfig, rootdir):
 #     """Test embedded instance saves ShowTriad value using a test-scoped Python environment."""
 #     version = pytestconfig.getoption("ansys_version")

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 """Miscellaneous embedding tests"""
-import datetime
+# import datetime
 import os
 import subprocess
 import sys
@@ -148,12 +148,12 @@ def test_warning_message(test_env, pytestconfig, rootdir):
 
 def print_stderr(process):
     while True:
-        print(datetime.datetime.now())
+        # print(datetime.datetime.now())
         line = process.stderr.readline()
         if not line:
             break
         print(line.rstrip().decode())
-    time.sleep(0.001)
+    # time.sleep(0.001)
 
 
 @pytest.mark.embedding

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -114,16 +114,6 @@ def test_app_getters_notstale(embedded_app):
     assert model.Name != "b"
 
 
-def print_stderr(process):
-    while True:
-        print(datetime.datetime.now())
-        line = process.stderr.readline()
-        if not line:
-            break
-        print(line.rstrip().decode())
-    time.sleep(0.001)
-
-
 @pytest.mark.embedding
 @pytest.mark.python_env
 def test_warning_message(test_env, pytestconfig, rootdir):
@@ -146,7 +136,6 @@ def test_warning_message(test_env, pytestconfig, rootdir):
         stderr=subprocess.PIPE,
         env=test_env.env,
     )
-    print_stderr(check_warning)
     stdout, stderr = check_warning.communicate()
 
     # If UserWarning & pythonnet are in the stderr output, set warning to True.
@@ -155,6 +144,16 @@ def test_warning_message(test_env, pytestconfig, rootdir):
 
     # Assert warning message appears for embedded app
     assert warning, "UserWarning should appear in the output of the script"
+
+
+def print_stderr(process):
+    while True:
+        print(datetime.datetime.now())
+        line = process.stderr.readline()
+        if not line:
+            break
+        print(line.rstrip().decode())
+    time.sleep(0.001)
 
 
 @pytest.mark.embedding

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -53,7 +53,6 @@ def _run_embedding_log_test_process(rootdir, pytestconfig, testname) -> subproce
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
         env=_get_env_without_logging_variables(),
-        close_fds=True,
     )
     p.wait()
     return p

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -53,6 +53,7 @@ def _run_embedding_log_test_process(rootdir, pytestconfig, testname) -> subproce
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
         env=_get_env_without_logging_variables(),
+        close_fds=True,
     )
     p.wait()
     return p

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -55,7 +55,7 @@ def _run_embedding_log_test_process(rootdir, pytestconfig, testname) -> subproce
         env=_get_env_without_logging_variables(),
         close_fds=True,
     )
-    p.wait()
+    p.communicate()
     return p
 
 

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -103,13 +103,14 @@ def test_logging_write_log_before_init(rootdir, pytestconfig):
     assert "Can't log to the embedding logger until Mechanical is initialized" in stderr
 
 
-@pytest.mark.embedding
-def test_logging_write_info_after_initialize_with_error_level(rootdir, pytestconfig):
-    """Test that no output is written when an info is logged when configured at the error level."""
-    stderr = _run_embedding_log_test(
-        rootdir, pytestconfig, "log_info_after_initialize_with_error_level"
-    )
-    assert "0xdeadbeef" not in stderr
+# @pytest.mark.embedding
+# def test_logging_write_info_after_initialize_with_error_level(rootdir, pytestconfig):
+#     """Test that no output is written when an info is logged when configured at
+# the error level."""
+#     stderr = _run_embedding_log_test(
+#         rootdir, pytestconfig, "log_info_after_initialize_with_error_level"
+#     )
+#     assert "0xdeadbeef" not in stderr
 
 
 # @pytest.mark.parametrize("addin_configuration", ["Mechanical", "WorkBench"])

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -103,25 +103,24 @@ def test_logging_write_log_before_init(rootdir, pytestconfig):
     assert "Can't log to the embedding logger until Mechanical is initialized" in stderr
 
 
-# @pytest.mark.embedding
-# def test_logging_write_info_after_initialize_with_error_level(rootdir, pytestconfig):
-#     """Test that no output is written when an info is logged when configured at
-# the error level."""
-#     stderr = _run_embedding_log_test(
-#         rootdir, pytestconfig, "log_info_after_initialize_with_error_level"
-#     )
-#     assert "0xdeadbeef" not in stderr
+@pytest.mark.embedding
+def test_logging_write_info_after_initialize_with_error_level(rootdir, pytestconfig):
+    """Test that no output is written when an info is logged when configured at the error level."""
+    stderr = _run_embedding_log_test(
+        rootdir, pytestconfig, "log_info_after_initialize_with_error_level"
+    )
+    assert "0xdeadbeef" not in stderr
 
 
-# @pytest.mark.parametrize("addin_configuration", ["Mechanical", "WorkBench"])
-# @pytest.mark.embedding
-# @pytest.mark.minimum_version(241)
-# def test_addin_configuration(rootdir, pytestconfig, addin_configuration):
-#     """Test that mechanical can start with both the Mechanical and WorkBench configuration."""
-#     stderr = _run_embedding_log_test(
-#         rootdir, pytestconfig, f"log_configuration_{addin_configuration}"
-#     )
-#     assert f"{addin_configuration} configuration!" in stderr
+@pytest.mark.parametrize("addin_configuration", ["Mechanical", "WorkBench"])
+@pytest.mark.embedding
+@pytest.mark.minimum_version(241)
+def test_addin_configuration(rootdir, pytestconfig, addin_configuration):
+    """Test that mechanical can start with both the Mechanical and WorkBench configuration."""
+    stderr = _run_embedding_log_test(
+        rootdir, pytestconfig, f"log_configuration_{addin_configuration}"
+    )
+    assert f"{addin_configuration} configuration!" in stderr
 
 
 @pytest.mark.embedding

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -112,15 +112,15 @@ def test_logging_write_info_after_initialize_with_error_level(rootdir, pytestcon
     assert "0xdeadbeef" not in stderr
 
 
-@pytest.mark.parametrize("addin_configuration", ["Mechanical", "WorkBench"])
-@pytest.mark.embedding
-@pytest.mark.minimum_version(241)
-def test_addin_configuration(rootdir, pytestconfig, addin_configuration):
-    """Test that mechanical can start with both the Mechanical and WorkBench configuration."""
-    stderr = _run_embedding_log_test(
-        rootdir, pytestconfig, f"log_configuration_{addin_configuration}"
-    )
-    assert f"{addin_configuration} configuration!" in stderr
+# @pytest.mark.parametrize("addin_configuration", ["Mechanical", "WorkBench"])
+# @pytest.mark.embedding
+# @pytest.mark.minimum_version(241)
+# def test_addin_configuration(rootdir, pytestconfig, addin_configuration):
+#     """Test that mechanical can start with both the Mechanical and WorkBench configuration."""
+#     stderr = _run_embedding_log_test(
+#         rootdir, pytestconfig, f"log_configuration_{addin_configuration}"
+#     )
+#     assert f"{addin_configuration} configuration!" in stderr
 
 
 @pytest.mark.embedding

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -96,6 +96,7 @@ def _run_embedding_log_test(
 
 
 @pytest.mark.embedding
+@pytest.mark.timeout(90)
 def test_logging_write_log_before_init(rootdir, pytestconfig):
     """Test that an error is thrown when trying to log before initializing"""
     stderr = _run_embedding_log_test(rootdir, pytestconfig, "log_before_initialize", False)
@@ -103,6 +104,7 @@ def test_logging_write_log_before_init(rootdir, pytestconfig):
 
 
 @pytest.mark.embedding
+@pytest.mark.timeout(90)
 def test_logging_write_info_after_initialize_with_error_level(rootdir, pytestconfig):
     """Test that no output is written when an info is logged when configured at the error level."""
     stderr = _run_embedding_log_test(
@@ -114,6 +116,7 @@ def test_logging_write_info_after_initialize_with_error_level(rootdir, pytestcon
 @pytest.mark.parametrize("addin_configuration", ["Mechanical", "WorkBench"])
 @pytest.mark.embedding
 @pytest.mark.minimum_version(241)
+@pytest.mark.timeout(180)
 def test_addin_configuration(rootdir, pytestconfig, addin_configuration):
     """Test that mechanical can start with both the Mechanical and WorkBench configuration."""
     stderr = _run_embedding_log_test(
@@ -123,6 +126,7 @@ def test_addin_configuration(rootdir, pytestconfig, addin_configuration):
 
 
 @pytest.mark.embedding
+@pytest.mark.timeout(90)
 def test_logging_write_error_after_initialize_with_info_level(rootdir, pytestconfig):
     """Test that output is written when an error is logged when configured at the info level."""
     stderr = _run_embedding_log_test(

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -55,11 +55,11 @@ def _run_embedding_log_test_process(rootdir, pytestconfig, testname) -> subproce
         env=_get_env_without_logging_variables(),
         close_fds=True,
     )
-    p.communicate()
-    return p
+    stdout, stderr = p.communicate()
+    return p, stdout, stderr
 
 
-def _assert_success(process: subprocess.Popen, pass_expected: bool) -> int:
+def _assert_success(process: subprocess.Popen, output, pass_expected: bool) -> int:
     """Asserts the outcome of the process matches pass_expected"""
     if os.name == "nt":
         passing = process.returncode == 0
@@ -71,7 +71,7 @@ def _assert_success(process: subprocess.Popen, pass_expected: bool) -> int:
     # throw. To check for the subprocess success, ensure that the stdout
     # has "@@success@@" (a value written there in the subprocess after the
     # test function runs)
-    stdout = process.stdout.read().decode()
+    stdout = output.decode()
     if pass_expected:
         assert "@@success@@" in stdout
     else:
@@ -90,10 +90,10 @@ def _run_embedding_log_test(
 
     Returns the stderr
     """
-    p = _run_embedding_log_test_process(rootdir, pytestconfig, testname)
-    stderr = p.stderr.read().decode()
-    _assert_success(p, pass_expected)
-    return stderr
+    p, stdout, stderr = _run_embedding_log_test_process(rootdir, pytestconfig, testname)
+    # stderr = p.stderr.read().decode()
+    _assert_success(p, stdout, pass_expected)
+    return stderr.decode()
 
 
 @pytest.mark.embedding
@@ -135,5 +135,5 @@ def test_logging_write_error_after_initialize_with_info_level(rootdir, pytestcon
 @pytest.mark.embedding
 def test_logging_level_before_and_after_initialization(rootdir, pytestconfig):
     """Test logging level API  before and after initialization."""
-    p = _run_embedding_log_test_process(rootdir, pytestconfig, "log_check_can_log_message")
-    _assert_success(p, True)
+    p, stdout, stderr = _run_embedding_log_test_process(rootdir, pytestconfig, "log_check_can_log_message")
+    _assert_success(p, stdout, True)

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -135,5 +135,7 @@ def test_logging_write_error_after_initialize_with_info_level(rootdir, pytestcon
 @pytest.mark.embedding
 def test_logging_level_before_and_after_initialization(rootdir, pytestconfig):
     """Test logging level API  before and after initialization."""
-    p, stdout, stderr = _run_embedding_log_test_process(rootdir, pytestconfig, "log_check_can_log_message")
+    p, stdout, stderr = _run_embedding_log_test_process(
+        rootdir, pytestconfig, "log_check_can_log_message"
+    )
     _assert_success(p, stdout, True)

--- a/tests/scripts/embedding_log_test.py
+++ b/tests/scripts/embedding_log_test.py
@@ -42,11 +42,11 @@ def log_info_after_initialize_with_error_level(version):
     Logger.info("0xdeadbeef")
 
 
-def log_error_after_initialize_with_info_level(version):
-    """Log at the info level after initializing with the error level."""
-    _ = mech.App(version=version)
-    Configuration.configure(level=logging.INFO, to_stdout=True, base_directory=None)
-    Logger.error("Will no one rid me of this turbulent priest?")
+# def log_error_after_initialize_with_info_level(version):
+#     """Log at the info level after initializing with the error level."""
+#     _ = mech.App(version=version)
+#     Configuration.configure(level=logging.INFO, to_stdout=True, base_directory=None)
+#     Logger.error("Will no one rid me of this turbulent priest?")
 
 
 def log_configuration_mechanical(version):

--- a/tests/scripts/embedding_log_test.py
+++ b/tests/scripts/embedding_log_test.py
@@ -52,14 +52,14 @@ def log_error_after_initialize_with_info_level(version):
 def log_configuration_mechanical(version):
     """Log at the info level after app starts with the `Mechanical` configuration."""
     _ = mech.App(version=version, config=AddinConfiguration("Mechanical"))
-    Configuration.configure(level=logging.INFO, to_stdout=True, base_directory=None)
+    Configuration.configure(level=logging.DEBUG, to_stdout=True, base_directory=None)
     Logger.error("Mechanical configuration!")
 
 
 def log_configuration_workbench(version):
     """Log at the info level after app starts with the `WorkBench` configuration."""
     _ = mech.App(version=version, config=AddinConfiguration("WorkBench"))
-    Configuration.configure(level=logging.INFO, to_stdout=True, base_directory=None)
+    Configuration.configure(level=logging.DEBUG, to_stdout=True, base_directory=None)
     Logger.error("WorkBench configuration!")
 
 

--- a/tests/scripts/embedding_log_test.py
+++ b/tests/scripts/embedding_log_test.py
@@ -40,7 +40,7 @@ def log_info_after_initialize_with_error_level(version):
     Configuration.configure(level=logging.ERROR, to_stdout=True, base_directory=None)
     _ = mech.App(version=version)
     Logger.info("0xdeadbeef")
-    _.close()
+    _.exit()
 
 
 def log_error_after_initialize_with_info_level(version):

--- a/tests/scripts/embedding_log_test.py
+++ b/tests/scripts/embedding_log_test.py
@@ -40,7 +40,6 @@ def log_info_after_initialize_with_error_level(version):
     Configuration.configure(level=logging.ERROR, to_stdout=True, base_directory=None)
     _ = mech.App(version=version)
     Logger.info("0xdeadbeef")
-    _.exit()
 
 
 def log_error_after_initialize_with_info_level(version):

--- a/tests/scripts/embedding_log_test.py
+++ b/tests/scripts/embedding_log_test.py
@@ -42,11 +42,11 @@ def log_info_after_initialize_with_error_level(version):
     Logger.info("0xdeadbeef")
 
 
-# def log_error_after_initialize_with_info_level(version):
-#     """Log at the info level after initializing with the error level."""
-#     _ = mech.App(version=version)
-#     Configuration.configure(level=logging.INFO, to_stdout=True, base_directory=None)
-#     Logger.error("Will no one rid me of this turbulent priest?")
+def log_error_after_initialize_with_info_level(version):
+    """Log at the info level after initializing with the error level."""
+    _ = mech.App(version=version)
+    Configuration.configure(level=logging.INFO, to_stdout=True, base_directory=None)
+    Logger.error("Will no one rid me of this turbulent priest?")
 
 
 def log_configuration_mechanical(version):

--- a/tests/scripts/embedding_log_test.py
+++ b/tests/scripts/embedding_log_test.py
@@ -40,6 +40,7 @@ def log_info_after_initialize_with_error_level(version):
     Configuration.configure(level=logging.ERROR, to_stdout=True, base_directory=None)
     _ = mech.App(version=version)
     Logger.info("0xdeadbeef")
+    _.close()
 
 
 def log_error_after_initialize_with_info_level(version):

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -21,14 +21,18 @@
 # SOFTWARE.
 
 """Launch embedded instance."""
+import logging
 import sys
 
 import ansys.mechanical.core as pymechanical
+
+logging.basicConfig(level=logging.DEBUG)
 
 
 def launch_app(version, private_appdata):
     """Launch embedded instance of app."""
     app = pymechanical.App(version=version, private_appdata=private_appdata)
+    logging.debug(app)
     return app
 
 

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -21,7 +21,6 @@
 # SOFTWARE.
 
 """Launch embedded instance."""
-import logging
 import sys
 
 import ansys.mechanical.core as pymechanical
@@ -30,14 +29,12 @@ import ansys.mechanical.core as pymechanical
 def launch_app(version, private_appdata):
     """Launch embedded instance of app."""
     app = pymechanical.App(version=version, private_appdata=private_appdata)
-    logging.error("Issue in launch_app %r", app)
     return app
 
 
 def set_showtriad(version, appdata_option, value):
     """Launch embedded instance of app & set ShowTriad to False."""
     app = launch_app(version, appdata_option)
-    logging.error("Issue in set_showtriad %r", app)
     app.ExtAPI.Graphics.ViewOptions.ShowTriad = value
     app.close()
 
@@ -45,7 +42,6 @@ def set_showtriad(version, appdata_option, value):
 def print_showtriad(version, appdata_option):
     """Return ShowTriad value."""
     app = launch_app(version, appdata_option)
-    logging.error("Issue in print_showtriad %r", app)
     print("ShowTriad value is " + str(app.ExtAPI.Graphics.ViewOptions.ShowTriad))
     app.close()
 
@@ -53,7 +49,6 @@ def print_showtriad(version, appdata_option):
 def reset_showtriad(version, appdata_option):
     """Reset ShowTriad value."""
     app = launch_app(version, appdata_option)
-    logging.error("Issue in reset_showtriad %r", app)
     app.ExtAPI.Graphics.ViewOptions.Reset
     app.close()
 

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -25,14 +25,13 @@ import logging
 import sys
 
 import ansys.mechanical.core as pymechanical
-
-logging.basicConfig(level=logging.DEBUG)
+from ansys.mechanical.core.embedding.logger import Configuration, Logger
 
 
 def launch_app(version, private_appdata):
     """Launch embedded instance of app."""
     app = pymechanical.App(version=version, private_appdata=private_appdata)
-    logging.debug(app)
+    Configuration.configure(level=logging.DEBUG, to_stdout=True, base_directory=None)
     return app
 
 

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -59,7 +59,8 @@ def reset_showtriad(version, appdata_option):
 if __name__ == "__main__":
     version = int(sys.argv[1])
     if len(sys.argv) == 2:
-        launch_app(version, False)
+        app = launch_app(version, False)
+        app.exit()
         sys.exit(0)
 
     appdata_option = sys.argv[2]

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -25,7 +25,7 @@ import logging
 import sys
 
 import ansys.mechanical.core as pymechanical
-from ansys.mechanical.core.embedding.logger import Configuration, Logger
+from ansys.mechanical.core.embedding.logger import Configuration
 
 
 def launch_app(version, private_appdata):

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -39,21 +39,21 @@ def set_showtriad(version, appdata_option, value):
     """Launch embedded instance of app & set ShowTriad to False."""
     app = launch_app(version, appdata_option)
     app.ExtAPI.Graphics.ViewOptions.ShowTriad = value
-    app.close()
+    app.exit()
 
 
 def print_showtriad(version, appdata_option):
     """Return ShowTriad value."""
     app = launch_app(version, appdata_option)
     print("ShowTriad value is " + str(app.ExtAPI.Graphics.ViewOptions.ShowTriad))
-    app.close()
+    app.exit()
 
 
 def reset_showtriad(version, appdata_option):
     """Reset ShowTriad value."""
     app = launch_app(version, appdata_option)
     app.ExtAPI.Graphics.ViewOptions.Reset
-    app.close()
+    app.exit()
 
 
 if __name__ == "__main__":

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -21,17 +21,14 @@
 # SOFTWARE.
 
 """Launch embedded instance."""
-import logging
 import sys
 
 import ansys.mechanical.core as pymechanical
-from ansys.mechanical.core.embedding.logger import Configuration
 
 
 def launch_app(version, private_appdata):
     """Launch embedded instance of app."""
     app = pymechanical.App(version=version, private_appdata=private_appdata)
-    Configuration.configure(level=logging.DEBUG, to_stdout=True, base_directory=None)
     return app
 
 

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """Launch embedded instance."""
+import logging
 import sys
 
 import ansys.mechanical.core as pymechanical
@@ -29,12 +30,14 @@ import ansys.mechanical.core as pymechanical
 def launch_app(version, private_appdata):
     """Launch embedded instance of app."""
     app = pymechanical.App(version=version, private_appdata=private_appdata)
+    logging.error("Issue in launch_app %r", app)
     return app
 
 
 def set_showtriad(version, appdata_option, value):
     """Launch embedded instance of app & set ShowTriad to False."""
     app = launch_app(version, appdata_option)
+    logging.error("Issue in set_showtriad %r", app)
     app.ExtAPI.Graphics.ViewOptions.ShowTriad = value
     app.close()
 
@@ -42,6 +45,7 @@ def set_showtriad(version, appdata_option, value):
 def print_showtriad(version, appdata_option):
     """Return ShowTriad value."""
     app = launch_app(version, appdata_option)
+    logging.error("Issue in print_showtriad %r", app)
     print("ShowTriad value is " + str(app.ExtAPI.Graphics.ViewOptions.ShowTriad))
     app.close()
 
@@ -49,6 +53,7 @@ def print_showtriad(version, appdata_option):
 def reset_showtriad(version, appdata_option):
     """Reset ShowTriad value."""
     app = launch_app(version, appdata_option)
+    logging.error("Issue in reset_showtriad %r", app)
     app.ExtAPI.Graphics.ViewOptions.Reset
     app.close()
 


### PR DESCRIPTION
- The stable versions are now 231, 232 and 241, and the dev version is 242
- By default, the tests are run on all versions with 242 being experimental and the others being stable
- In the embedding-tests and launch-tests sections, the older stable container numbers are hardcoded (231, 232). The coverage tests are posted for the most recent stable revn (241)
- the doc-build step previously used the dev image, but it's using the latest stable image now (24.1.0)

Will make separate issue to address this:
- remove "scheduled" workflow event and replaced it with "registry_package." This means the workflow will be triggered any time a package is published or updated