### PR TITLE
Fix private appdata environment variables and folder layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
  - Flexible version for embedding & remote example ([#459](https://github.com/ansys/pymechanical/pull/459))
  - Fix obsolete API call in embedding test ([#456](https://github.com/ansys/pymechanical/pull/456))
  - Fix ignored env passing to cli ([#465](https://github.com/ansys/pymechanical/pull/465)
+ - Fix private appdata environment variables and folder layout ([#474](https://github.com/ansys/pymechanical/pull/474))
 
 ### Changed
 

--- a/src/ansys/mechanical/core/embedding/appdata.py
+++ b/src/ansys/mechanical/core/embedding/appdata.py
@@ -68,6 +68,8 @@ class UniqueUserProfile:
             env["USERPROFILE"] = home
             env["APPDATA"] = os.path.join(home, "AppData/Roaming")
             env["LOCALAPPDATA"] = os.path.join(home, "AppData/Local")
+            env["TMP"] = os.path.join(home, "AppData/Local/Temp")
+            env["TEMP"] = os.path.join(home, "AppData/Local/Temp")
         elif "lin" in sys.platform:
             env["HOME"] = home
 

--- a/src/ansys/mechanical/core/embedding/appdata.py
+++ b/src/ansys/mechanical/core/embedding/appdata.py
@@ -34,7 +34,7 @@ class UniqueUserProfile:
     def __init__(self, profile_name):
         """Initialize UniqueUserProfile class."""
         self._default_profile = os.path.expanduser("~")
-        self._location = os.path.join(self._default_profile, profile_name)
+        self._location = os.path.join(self._default_profile, "PyMechanical-AppData", profile_name)
         self.initialize()
 
     def initialize(self) -> None:
@@ -79,7 +79,7 @@ class UniqueUserProfile:
 
     def mkdirs(self) -> None:
         """Create a unique user profile & set up the directory tree."""
-        os.makedirs(self.location)
+        os.makedirs(self.location, exist_ok=True)
         if "win" in sys.platform:
             locs = ["AppData/Roaming", "AppData/Local", "Documents"]
         elif "lin" in sys.platform:


### PR DESCRIPTION
- Added env["TMP"] and env["TEMP"] paths for private_appdata to fix the issue when AnsysWBU.exe encounters a problem and the diagnostic file is written to C:\Users\username\AppData\Local\Temp\number\AnsysWBDumpFile.dmp

- Added a "PyMechanical-AppData" folder that contains "PyMechanical-pid" folders to make deleting the temporary appdata directories manually easier. This could be removed once the complete deletion of the PyMechanical-pid folders works 