### PR TITLE
Fix hanging embedding tests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -261,7 +261,6 @@ jobs:
       image: ghcr.io/ansys/mechanical:${{needs.revn-variations.outputs.experimental_container_revn}}
       options: --entrypoint /bin/bash
     strategy:
-      max-parallel: 2
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
  - Fix obsolete API call in embedding test ([#456](https://github.com/ansys/pymechanical/pull/456))
  - Fix ignored env passing to cli ([#465](https://github.com/ansys/pymechanical/pull/465)
  - Fix private appdata environment variables and folder layout ([#474](https://github.com/ansys/pymechanical/pull/474))
+ - Fix hanging embedding tests ([#498](https://github.com/ansys/pymechanical/pull/498))
 
 ### Changed
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -135,12 +135,11 @@ def test_warning_message(test_env, pytestconfig, rootdir):
         stderr=subprocess.PIPE,
         env=test_env.env,
     )
-    check_warning.wait()
-    stderr = check_warning.stderr.read().decode()
+    stdout, stderr = check_warning.communicate()
 
     # If UserWarning & pythonnet are in the stderr output, set warning to True.
     # Otherwise, set warning to False
-    warning = True if "UserWarning" and "pythonnet" in stderr else False
+    warning = True if "UserWarning" and "pythonnet" in stderr.decode() else False
 
     # Assert warning message appears for embedded app
     assert warning, "UserWarning should appear in the output of the script"
@@ -158,16 +157,15 @@ def test_private_appdata(pytestconfig, rootdir):
     p1 = subprocess.Popen(
         [sys.executable, embedded_py, version, "True", "Set"], stdout=subprocess.PIPE
     )
-    p1.wait()
+    p1.communicate()
 
     # Check ShowTriad is True for private_appdata embedded sessions
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "True", "Run"], stdout=subprocess.PIPE
     )
-    p2.wait()
-    stdout = p2.stdout.read().decode()
+    stdout, stderr = p2.communicate()
 
-    assert "ShowTriad value is True" in stdout
+    assert "ShowTriad value is True" in stdout.decode()
 
 
 @pytest.mark.embedding
@@ -182,23 +180,22 @@ def test_normal_appdata(pytestconfig, rootdir):
     p1 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Set"], stdout=subprocess.PIPE
     )
-    p1.wait()
+    p1.communicate()
 
     # Check ShowTriad is False for regular embedded session
     p2 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Run"], stdout=subprocess.PIPE
     )
-    p2.wait()
-    stdout = p2.stdout.read().decode()
+    stdout, stderr = p2.communicate()
 
     # Set ShowTriad back to True for regular embedded session
     p3 = subprocess.Popen(
         [sys.executable, embedded_py, version, "False", "Reset"], stdout=subprocess.PIPE
     )
-    p3.wait()
+    p3.communicate()
 
     # Assert ShowTriad was set to False for regular embedded session
-    assert "ShowTriad value is False" in stdout
+    assert "ShowTriad value is False" in stdout.decode()
 
 
 @pytest.mark.embedding

--- a/tests/test_mechanical.py
+++ b/tests/test_mechanical.py
@@ -575,7 +575,7 @@ def test_warning_message_default():
     # Run remote session
     remote_py = os.path.join(base, "tests", "scripts", "run_remote_session.py")
     check_warning = subprocess.Popen([sys.executable, remote_py], stderr=subprocess.PIPE)
-    stdout, stderr = check_warning.commnicate()
+    stdout, stderr = check_warning.communicate()
 
     # If UserWarning & pythonnet are in the stderr output, set warning to True.
     # Otherwise, set warning to False

--- a/tests/test_mechanical.py
+++ b/tests/test_mechanical.py
@@ -557,12 +557,11 @@ def test_warning_message_pythonnet(test_env, rootdir):
         stderr=subprocess.PIPE,
         env=test_env.env,
     )
-    check_warning.wait()
-    stderr = check_warning.stderr.read().decode()
+    stdout, stderr = check_warning.communicate()
 
     # If UserWarning & pythonnet are in the stderr output, set warning to True.
     # Otherwise, set warning to False
-    warning = True if "UserWarning" and "pythonnet" in stderr else False
+    warning = True if "UserWarning" and "pythonnet" in stderr.decode() else False
 
     # Assert the warning message did not appear for the remote session
     assert not warning
@@ -576,12 +575,11 @@ def test_warning_message_default():
     # Run remote session
     remote_py = os.path.join(base, "tests", "scripts", "run_remote_session.py")
     check_warning = subprocess.Popen([sys.executable, remote_py], stderr=subprocess.PIPE)
-    check_warning.wait()
-    stderr_output = check_warning.stderr.read().decode()
+    stdout, stderr = check_warning.commnicate()
 
     # If UserWarning & pythonnet are in the stderr output, set warning to True.
     # Otherwise, set warning to False
-    warning = True if "UserWarning" and "pythonnet" in stderr_output else False
+    warning = True if "UserWarning" and "pythonnet" in stderr.decode() else False
 
     # Assert the warning message did not appear for the remote session
     assert not warning


### PR DESCRIPTION
Change Popen.wait() to Popen.communicate() due to this warning: https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait

Removed max_parallel in embedding test section

Closes #460 