### PR TITLE
Add 242 to scheduled nightly run

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -18,10 +18,9 @@ on:
         type: choice
         description: 'The experimental mechanical install revision number.'
         options:
+        - '242'
         - '241'
-        - '232'
-        - '231'
-        default: '232'  # ensure this matches env.EXPERIMENTAL_REVN
+        default: '241'  # ensure this matches env.DEV_REVN
   push:
     tags:
       - "*"
@@ -40,8 +39,8 @@ env:
   RESET_DOC_BUILD_CACHE: 0
   MAIN_PYTHON_VERSION: '3.10'
   STABLE_REVN: '231'  # ensure this matches inputs.stable-revn.default
-  EXPERIMENTAL_REVN: '232'  # ensure this matches inputs.experimental-revn.default
-  DEV_REVN: '241'
+  EXPERIMENTAL_REVN: '232'
+  DEV_REVN: '241'  # ensure this matches inputs.experimental-revn.default
   MEILISEARCH_API_KEY: ${{ secrets.MEILISEARCH_API_KEY }}
   MEILISEARCH_HOST_URL: ${{ vars.MEILISEARCH_HOST_URL }}
   MEILISEARCH_PUBLIC_API_KEY: ${{ secrets.MEILISEARCH_PUBLIC_API_KEY }}
@@ -90,7 +89,7 @@ jobs:
 
           if ${{ github.event_name == 'schedule' }}; then
               # Scheduled runs use the DEV_REVN environment variable
-              parse_revns "${{ env.DEV_REVN }}" "${{ env.DEV_REVN }}"
+              parse_revns "${{ env.DEV_REVN }}" "242"
           elif ${{ github.event_name == 'workflow_dispatch' }}; then
               # Manual workflow dispatches use the user-selected revision numbers
               parse_revns "${{ inputs.stable-revn }}" "${{ inputs.experimental-revn }}"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -20,7 +20,8 @@ on:
         options:
         - '242'
         - '241'
-        default: '241'  # ensure this matches env.DEV_REVN
+        - '232'
+        default: '232'  # ensure this matches env.EXPERIMENTAL_REVN
   push:
     tags:
       - "*"
@@ -39,8 +40,8 @@ env:
   RESET_DOC_BUILD_CACHE: 0
   MAIN_PYTHON_VERSION: '3.10'
   STABLE_REVN: '231'  # ensure this matches inputs.stable-revn.default
-  EXPERIMENTAL_REVN: '232'
-  DEV_REVN: '241'  # ensure this matches inputs.experimental-revn.default
+  EXPERIMENTAL_REVN: '232' # ensure this matches inputs.experimental-revn.default
+  DEV_REVN: '241'
   MEILISEARCH_API_KEY: ${{ secrets.MEILISEARCH_API_KEY }}
   MEILISEARCH_HOST_URL: ${{ vars.MEILISEARCH_HOST_URL }}
   MEILISEARCH_PUBLIC_API_KEY: ${{ secrets.MEILISEARCH_PUBLIC_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 - add readonly flag and assertion ([#441](https://github.com/ansys/pymechanical/pull/441))
 - Add PyMeilisearch in documentation ([#508](https://github.com/ansys/pymechanical/pull/508))
 - Add cheetsheat and improve example visibility ([#506](https://github.com/ansys/pymechanical/pull/506))
+- Add 242 to scheduled nightly run ([#519](https://github.com/ansys/pymechanical/pull/519))
 
 ### Fixed
 


### PR DESCRIPTION
Runs 241 and 242 nightly, with 241 being stable and 242 being experimental.

Still working on improving the workflow in fix/workflow-versions, but this change should be fine in the meantime for incorporating 242 testing.