### PR TITLE
Revert "Bump ansys-mechanical-env from 0.1.0 to 0.1.1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 - Bump `pytest` from 7.4.3 to 7.4.4 ([#546](https://github.com/ansys/pymechanical/pull/546))
 - Bump `add-license-headers` from 0.2.2 to 0.2.4 ([#549](https://github.com/ansys/pymechanical/pull/549))
 - Bump `numpy` from 1.26.2 to 1.26.3 ([#551](https://github.com/ansys/pymechanical/pull/551))
-- Bump `ansys-mechanical-env` from 0.1.0 to 0.1.1 ([#552](https://github.com/ansys/pymechanical/pull/552))
 
 ## [0.10.5](https://github.com/ansys/pymechanical/releases/tag/v0.10.5) - December 15, 2023
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "ansys_api_mechanical==0.1.1",
-    "ansys-mechanical-env==0.1.1",
+    "ansys-mechanical-env==0.1.0",
     "ansys-platform-instancemanagement>=1.0.1",
     "ansys-pythonnet>=3.1.0rc2",
     "ansys-tools-path>=0.3.1",


### PR DESCRIPTION
Reverts ansys/pymechanical#552

@RobPasMue there is bug to be fixed in mechanical -env, so not upgrading to 1.1. will fix that in mechanical-env 1.2