### PR TITLE
add poster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 ## [Unreleased]()
 
 ### Added
+- add poster ([#642](https://github.com/ansys/pymechanical/pull/642))
 - Add LS Dyna unit test ([#584](https://github.com/ansys/pymechanical/pull/584))
 
 ### Fixed

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -27,6 +27,7 @@ import os
 from ansys.mechanical.core.embedding import initializer, runtime
 from ansys.mechanical.core.embedding.addins import AddinConfiguration
 from ansys.mechanical.core.embedding.appdata import UniqueUserProfile
+from ansys.mechanical.core.embedding.poster import Poster
 from ansys.mechanical.core.embedding.warnings import connect_warnings, disconnect_warnings
 
 
@@ -125,8 +126,9 @@ class App:
             atexit.register(_cleanup_private_appdata, profile)
 
         self._app = _start_application(configuration, self._version, db_file)
-        runtime.initialize()
+        runtime.initialize(self._version)
         connect_warnings(self)
+        self._poster = None
 
         self._disposed = False
         atexit.register(_dispose_embedded_app, INSTANCES)
@@ -209,6 +211,13 @@ class App:
         args = None
         rets = None
         return self.script_engine.ExecuteCode(script, SCRIPT_SCOPE, light_mode, args, rets)
+
+    @property
+    def poster(self) -> Poster:
+        """Returns an instance of Poster."""
+        if self._poster == None:
+            self._poster = Poster()
+        return self._poster
 
     @property
     def DataModel(self):

--- a/src/ansys/mechanical/core/embedding/poster.py
+++ b/src/ansys/mechanical/core/embedding/poster.py
@@ -22,14 +22,17 @@
 
 import typing
 
-class Poster():
+
+class Poster:
     """Class which can post a python callable function  to Mechanical's main thread."""
 
     def __init__(self):
         """Create a new instance of Poster."""
         import clr
+
         clr.AddReference("Ans.Common.WB1ManagedUtils")
         import Ans
+
         self._poster = Ans.Common.WB1ManagedUtils.TaskPoster
 
     def post(self, callable: typing.Callable):
@@ -40,5 +43,6 @@ class Poster():
         the `sleep` routine from the `utils` module to make
         Mechanical available to receive messages."""
         import System
+
         action = System.Action(callable)
         self._poster.Post(action)

--- a/src/ansys/mechanical/core/embedding/poster.py
+++ b/src/ansys/mechanical/core/embedding/poster.py
@@ -20,11 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""Use the Poster class to post functions to Mechanical's main thread."""
+
 import typing
 
 
 class Poster:
-    """Class which can post a python callable function  to Mechanical's main thread."""
+    """Class which can post a python callable function to Mechanical's main thread."""
 
     def __init__(self):
         """Create a new instance of Poster."""
@@ -41,7 +43,8 @@ class Poster:
         The main thread needs to be receiving posted messages
         in order for this to work from a background thread. Use
         the `sleep` routine from the `utils` module to make
-        Mechanical available to receive messages."""
+        Mechanical available to receive messages.
+        """
         import System
 
         action = System.Action(callable)

--- a/src/ansys/mechanical/core/embedding/runtime.py
+++ b/src/ansys/mechanical/core/embedding/runtime.py
@@ -26,6 +26,7 @@ import os
 
 from ansys.mechanical.core.embedding.logger import Logger
 
+
 def __register_container_codecs():
     import Python.Runtime.Codecs as codecs
 
@@ -36,8 +37,10 @@ def __register_container_codecs():
 
 def __register_function_codec():
     import clr
+
     clr.AddReference("Ansys.Mechanical.CPython")
     import Ansys
+
     Ansys.Mechanical.CPython.Codecs.FunctionCodec.Register()
 
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -92,6 +92,51 @@ def test_nonblock_sleep(embedded_app):
     assert (t2 - t1) >= 2
 
 
+
+@pytest.mark.embedding
+def test_app_poster(embedded_app):
+    """The getters of app should be usable after a new().
+
+    The C# objects referred to by ExtAPI, Model, DataModel, and Tree
+    are reset on each call to app.new(), so storing them in
+    global variables will be broken.
+
+    To resolve this, we have to wrap those objects, and ensure
+    that they properly redirect the calls to the appropriate C#
+    object after a new()
+    """
+    version = embedded_app.version
+    if os.name != "nt" and version < 242:
+        """ This test is effectively disabled for versions older than 242 on linux.
+
+        This is because the function coded is distributed with the C# library
+        Ansys.Mechanical.CPython.dll. That library only began to be shipping on
+        linux in 2024 R2.
+        """
+        return
+    poster = embedded_app.poster
+    def change_name_async(poster):
+        """Change_name_async will run a background thread
+
+        It will change the name of the project to "foo"
+        """
+        def change_name():
+            embedded_app.DataModel.Project.Name = "foo"
+        poster.post(change_name)
+
+    import threading
+    change_name_thread = threading.Thread(target=change_name_async, args=(poster,))
+    change_name_thread.start()
+
+    # The poster can't do anything unless the main thread is receiving
+    # messages. The `sleep` utility puts Mechanical's main thread to
+    # idle and only execute actions that have been posted to its main
+    # thread, e.g. `change_name` that was posted by the poster.
+    utils.sleep(400)
+    change_name_thread.join()
+    assert embedded_app.DataModel.Project.Name == "foo"
+
+
 @pytest.mark.embedding
 def test_app_getters_notstale(embedded_app):
     """The getters of app should be usable after a new().

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -92,7 +92,6 @@ def test_nonblock_sleep(embedded_app):
     assert (t2 - t1) >= 2
 
 
-
 @pytest.mark.embedding
 def test_app_poster(embedded_app):
     """The getters of app should be usable after a new().
@@ -107,7 +106,7 @@ def test_app_poster(embedded_app):
     """
     version = embedded_app.version
     if os.name != "nt" and version < 242:
-        """ This test is effectively disabled for versions older than 242 on linux.
+        """This test is effectively disabled for versions older than 242 on linux.
 
         This is because the function coded is distributed with the C# library
         Ansys.Mechanical.CPython.dll. That library only began to be shipping on
@@ -115,16 +114,20 @@ def test_app_poster(embedded_app):
         """
         return
     poster = embedded_app.poster
+
     def change_name_async(poster):
         """Change_name_async will run a background thread
 
         It will change the name of the project to "foo"
         """
+
         def change_name():
             embedded_app.DataModel.Project.Name = "foo"
+
         poster.post(change_name)
 
     import threading
+
     change_name_thread = threading.Thread(target=change_name_async, args=(poster,))
     change_name_thread.start()
 


### PR DESCRIPTION

`Poster` allows background threads to post to the main thread of mechanical.  This is necessary because mechanical is not
thread safe (or even thread compatible). Mechanical's API doesn't work on background threads.