### PR TITLE
Use _run for better i/o in tests

### DIFF
--- a/src/ansys/mechanical/core/run.py
+++ b/src/ansys/mechanical/core/run.py
@@ -78,6 +78,7 @@ def _run(args, env):
             sys.exit("child failed with '{}' exit code".format(rc))
     finally:
         loop.close()
+    return output
 
 
 @click.command()
@@ -247,6 +248,5 @@ def cli(
         print(f"Serving on port {port}")
 
     _run(args, env)
-
     if private_appdata:
         profile.cleanup()

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -201,18 +201,9 @@ def test_private_appdata(pytestconfig, rootdir):
     version = pytestconfig.getoption("ansys_version")
     embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
 
-    # Set ShowTriad to False
-    p1 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "True", "Set"], stdout=subprocess.PIPE
-    )
-    p1.communicate()
-
-    # Check ShowTriad is True for private_appdata embedded sessions
-    p2 = subprocess.Popen(
-        [sys.executable, embedded_py, version, "True", "Run"], stdout=subprocess.PIPE
-    )
-    stdout, stderr = p2.communicate()
-
+    from ansys.mechanical.core.run import _run
+    stdout, stderr = _run([sys.executable, embedded_py, version, "True", "Set"], None)
+    stdout, stderr = _run([sys.executable, embedded_py, version, "True", "Run"], None)
     assert "ShowTriad value is True" in stdout.decode()
 
 


### PR DESCRIPTION
This fixes the test instability.  We did this it in the debug branch but never merged it into main!