### PR TITLE
maint: use ansys-sphinx-theme "autoapi" target

### DIFF
--- a/doc/changelog.d/675.dependencies.md
+++ b/doc/changelog.d/675.dependencies.md
@@ -1,0 +1,1 @@
+maint: use ansys-sphinx-theme autoapi target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tests = [
 ]
 doc = [
     "Sphinx==7.2.6",
-    "ansys-sphinx-theme==0.15.0",
+    "ansys-sphinx-theme[autoapi]==0.15.1",
     "grpcio==1.62.1",
     "imageio-ffmpeg==0.4.9",
     "imageio==2.34.0",


### PR DESCRIPTION
Use the ansys-sphinx-theme "autoapi" target.