### PR TITLE
Fix: Modify retrieving path of Mechanical in tests

### DIFF
--- a/doc/changelog.d/688.fixed.md
+++ b/doc/changelog.d/688.fixed.md
@@ -1,0 +1,1 @@
+Fix: Modify retrieving path of Mechanical in tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,7 +312,7 @@ def mechanical_pool():
     if not pymechanical.mechanical.get_start_instance():
         return None
 
-    path, version = atp.find_mechanical()
+    path = atp.get_mechanical_path()
 
     exec_file = path
     instances_count = 2

--- a/tests/test_mechanical.py
+++ b/tests/test_mechanical.py
@@ -443,7 +443,7 @@ def test_find_mechanical_path():
         else:
             assert ".workbench" in path
 
-        assert re.match(r"\d{3}\.\d", str(version)) and version >= 231
+        assert re.match(r"\d{3}", str(version)) and version >= 231
 
 
 @pytest.mark.remote_session_launch

--- a/tests/test_mechanical.py
+++ b/tests/test_mechanical.py
@@ -435,7 +435,8 @@ def test_launch_result_mode(mechanical_result):
 @pytest.mark.remote_session_launch
 def test_find_mechanical_path():
     if pymechanical.mechanical.get_start_instance():
-        path, version = ansys.tools.path.find_mechanical()
+        path = ansys.tools.path.get_mechanical_path()
+        version = ansys.tools.path.version_from_path("mechanical", path)
 
         if misc.is_windows():
             assert "AnsysWBU.exe" in path
@@ -448,11 +449,13 @@ def test_find_mechanical_path():
 @pytest.mark.remote_session_launch
 def test_change_default_mechanical_path():
     if pymechanical.mechanical.get_start_instance():
-        path, version = ansys.tools.path.find_mechanical()
+        path = ansys.tools.path.get_mechanical_path()
+        version = ansys.tools.path.version_from_path("mechanical", path)
 
         pymechanical.change_default_mechanical_path(path)
 
-        path_new, version_new = ansys.tools.path.find_mechanical()
+        path_new = ansys.tools.path.get_mechanical_path()
+        version_new = ansys.tools.path.version_from_path("mechanical", path)
 
         assert path_new == path
         assert version_new == version

--- a/tests/test_mechanical.py
+++ b/tests/test_mechanical.py
@@ -443,7 +443,7 @@ def test_find_mechanical_path():
         else:
             assert ".workbench" in path
 
-        assert re.match(r"\d\d\.\d", str(version))
+        assert re.match(r"\d{3}\.\d", str(version)) and version >= 231
 
 
 @pytest.mark.remote_session_launch


### PR DESCRIPTION
Use `get_mechanical_path` instead of `find_mechanical` in `remote_session_launch` tests