### PR TITLE
fix: merging coverage step in ci_cd

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -209,7 +209,6 @@ jobs:
       - name: Upload coverage results (as .coverage)
         uses: actions/upload-artifact@v4
         if: matrix.mechanical-version == env.LATEST_STABLE_DOCKER_IMAGE_VERSION
-
         with:
           name: coverage-file-tests
           path: .coverage

--- a/doc/changelog.d/720.fixed.md
+++ b/doc/changelog.d/720.fixed.md
@@ -1,0 +1,1 @@
+fix: merging coverage step in ci_cd


### PR DESCRIPTION
Extra newline in the upload coverage-file-tests step caused "coverage-file-tests" to not be uploaded, which made merging coverage fail