### PR TITLE
fix: Publish coverage for remote connect

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -200,7 +200,6 @@ jobs:
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v4
-        if: matrix.mechanical-version == env.LATEST_STABLE_DOCKER_IMAGE_VERSION
         with:
           name: coverage-tests
           path: .cov
@@ -208,8 +207,6 @@ jobs:
 
       - name: Upload coverage results (as .coverage)
         uses: actions/upload-artifact@v4
-        if: matrix.mechanical-version == env.LATEST_STABLE_DOCKER_IMAGE_VERSION
-
         with:
           name: coverage-file-tests
           path: .coverage

--- a/doc/changelog.d/721.fixed.md
+++ b/doc/changelog.d/721.fixed.md
@@ -1,0 +1,1 @@
+fix: Publish coverage for remote connect


### PR DESCRIPTION
Currently coverage for remote connects are being published only for stable image versions. This causes issue in nightly run where image is test version(242). Hence unable to do merge coverage.