### PR TITLE
fix: adding mechanical libraries

### DIFF
--- a/doc/changelog.d/740.fixed.md
+++ b/doc/changelog.d/740.fixed.md
@@ -1,0 +1,1 @@
+fix: adding mechanical libraries

--- a/doc/source/user_guide_embedding/libraries.rst
+++ b/doc/source/user_guide_embedding/libraries.rst
@@ -33,4 +33,4 @@ To use the above function, run the following:
 
 .. warning::
 
-    Using version as argument to ``add_mechanical_python_libraries()``is deprecated.
+    Using version as argument to ``add_mechanical_python_libraries()`` is deprecated.

--- a/doc/source/user_guide_embedding/libraries.rst
+++ b/doc/source/user_guide_embedding/libraries.rst
@@ -28,5 +28,5 @@ To use the above function, run the following:
 
    app = App(version=241)
 
-   add_mechanical_python_libraries(241)
+   add_mechanical_python_libraries(app)
    import materials  # This is materials.py that's shipped with Mechanical v241

--- a/doc/source/user_guide_embedding/libraries.rst
+++ b/doc/source/user_guide_embedding/libraries.rst
@@ -30,3 +30,7 @@ To use the above function, run the following:
 
    add_mechanical_python_libraries(app)
    import materials  # This is materials.py that's shipped with Mechanical v241
+
+.. warning::
+
+    Using version as argument to ``add_mechanical_python_libraries()``is deprecated.

--- a/src/ansys/mechanical/core/embedding/app_libraries.py
+++ b/src/ansys/mechanical/core/embedding/app_libraries.py
@@ -62,8 +62,8 @@ def add_mechanical_python_libraries(app_or_version):
     installdir = []
     if isinstance(app_or_version, int):
         warnings.warn(
-            "Passing version to add_mechanical_python_libraries() is obsolete."
-            "Please pass a App() instead.",
+            "Passing version to add_mechanical_python_libraries() is deprecated."
+            "Please pass an instance of App() instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/ansys/mechanical/core/embedding/app_libraries.py
+++ b/src/ansys/mechanical/core/embedding/app_libraries.py
@@ -51,11 +51,9 @@ can be imported with the `import` statement.
 import os
 import sys
 
-from ansys.tools.path.path import _get_unified_install_base_for_version
 
-
-def add_mechanical_python_libraries(version: int):
+def add_mechanical_python_libraries(app: "ansys.mechanical.core.App"):
     """Add the Mechanical libraries path to sys.path."""
-    install, _ = _get_unified_install_base_for_version(version)
-    location = os.path.join(install, "Addins", "ACT", "libraries", "Mechanical")
+    installdir = os.environ[f"AWP_ROOT{app.version}"]
+    location = os.path.join(installdir, "Addins", "ACT", "libraries", "Mechanical")
     sys.path.append(location)

--- a/src/ansys/mechanical/core/embedding/app_libraries.py
+++ b/src/ansys/mechanical/core/embedding/app_libraries.py
@@ -50,10 +50,30 @@ can be imported with the `import` statement.
 
 import os
 import sys
+import typing
+import warnings
 
+from ansys.tools.path.path import get_mechanical_path
+from ansys.mechanical.core.embedding.app import App
 
-def add_mechanical_python_libraries(app: "ansys.mechanical.core.App"):
+def add_mechanical_python_libraries(app_or_version):
     """Add the Mechanical libraries path to sys.path."""
-    installdir = os.environ[f"AWP_ROOT{app.version}"]
-    location = os.path.join(installdir, "Addins", "ACT", "libraries", "Mechanical")
+    installdir = []
+    if isinstance(app_or_version, int):
+        warnings.warn(
+            "Passing version to add_mechanical_python_libraries() is obsolete."
+            "Please pass a App() instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        exe = get_mechanical_path(allow_input=False, version=app_or_version)
+        while os.path.basename(exe) != f"v{app_or_version}":
+            exe = os.path.dirname(exe)
+        installdir.append(exe)
+    elif isinstance(app_or_version, App):
+        installdir.append(os.environ[f"AWP_ROOT{app_or_version.version}"])
+    else:
+        raise ValueError(f"Input should be either version or App()")
+    
+    location = os.path.join(installdir[0], "Addins", "ACT", "libraries", "Mechanical")
     sys.path.append(location)

--- a/src/ansys/mechanical/core/embedding/app_libraries.py
+++ b/src/ansys/mechanical/core/embedding/app_libraries.py
@@ -50,11 +50,12 @@ can be imported with the `import` statement.
 
 import os
 import sys
-import typing
 import warnings
 
-from ansys.tools.path.path import get_mechanical_path
+from ansys.tools.path import get_mechanical_path
+
 from ansys.mechanical.core.embedding.app import App
+
 
 def add_mechanical_python_libraries(app_or_version):
     """Add the Mechanical libraries path to sys.path."""
@@ -64,7 +65,7 @@ def add_mechanical_python_libraries(app_or_version):
             "Passing version to add_mechanical_python_libraries() is obsolete."
             "Please pass a App() instead.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         exe = get_mechanical_path(allow_input=False, version=app_or_version)
         while os.path.basename(exe) != f"v{app_or_version}":
@@ -73,7 +74,7 @@ def add_mechanical_python_libraries(app_or_version):
     elif isinstance(app_or_version, App):
         installdir.append(os.environ[f"AWP_ROOT{app_or_version.version}"])
     else:
-        raise ValueError(f"Input should be either version or App()")
-    
+        raise ValueError(f"Invalid input: expected an integer (version) or an instance of App().")
+
     location = os.path.join(installdir[0], "Addins", "ACT", "libraries", "Mechanical")
     sys.path.append(location)

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -47,6 +47,7 @@ def test_deprecation_warning(embedded_app):
     harmonic_acoustic = embedded_app.Model.AddHarmonicAcousticAnalysis()
     with pytest.warns(UserWarning):
         harmonic_acoustic.SystemID
+    with pytest.warns(UserWarning):
         harmonic_acoustic.AnalysisSettings.MultipleRPMs = True
 
 

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -47,6 +47,9 @@ def test_deprecation_warning(embedded_app):
     struct = embedded_app.Model.AddStaticStructuralAnalysis()
     with pytest.warns(UserWarning):
         struct.SystemID
+    harmonic_acoustic = embedded_app.Model.AddHarmonicAcousticAnalysis()
+    with pytest.warns(UserWarning):
+        harmonic_acoustic.AnalysisSettings.MultipleRPMs = True
 
 
 @pytest.mark.embedding

--- a/tests/embedding/test_app_libraries.py
+++ b/tests/embedding/test_app_libraries.py
@@ -28,19 +28,39 @@ import sys
 import pytest
 
 from ansys.mechanical.core.embedding import add_mechanical_python_libraries
+from ansys.tools.path import get_mechanical_path
 
 
 @pytest.mark.embedding
 def test_app_library(embedded_app):
     """Loads one of the libraries and calls a method."""
-    add_mechanical_python_libraries(embedded_app)
-    app_installdir = os.environ[f"AWP_ROOT{embedded_app.version}"]
-    app_library_location = os.path.join(app_installdir, "Addins", "ACT", "libraries", "Mechanical")
-    assert app_library_location in sys.path
+    _version = embedded_app.version
+    
+    # Test with version as input
+    exe = get_mechanical_path(_version)
+    while os.path.basename(exe) != f"v{_version}":
+        exe = os.path.dirname(exe)
+
+    location = os.path.join(exe, "Addins", "ACT", "libraries", "Mechanical")
+    add_mechanical_python_libraries(_version)
+    print(sys.path)
+    print(location)
+    # assert location in sys.path
+    # sys.path.remove(location)
+    # assert location not in sys.path
+
+    # # Test with app as input
+    # add_mechanical_python_libraries(embedded_app)
+    # installdir = os.environ[f"AWP_ROOT{embedded_app.version}"]
+    # location = os.path.join(installdir, "Addins", "ACT", "libraries", "Mechanical")
+    # assert location in sys.path
 
     # import mechanical library and test a method
 
-    from mechanical import AnalysisTypeName
+    # from mechanical import AnalysisTypeName
 
-    analysis_name = AnalysisTypeName(0)
-    assert analysis_name == "Static"
+    # analysis_name = AnalysisTypeName(0)
+    # assert analysis_name == "Static"
+
+    # sys.path.remove(location)
+    # assert location not in sys.path

--- a/tests/embedding/test_app_libraries.py
+++ b/tests/embedding/test_app_libraries.py
@@ -62,3 +62,7 @@ def test_app_library(embedded_app):
 
     sys.path.remove(location)
     assert location not in sys.path
+
+    # Test value error
+    with pytest.raises(ValueError):
+        add_mechanical_python_libraries(embedded_app.Model)

--- a/tests/embedding/test_app_libraries.py
+++ b/tests/embedding/test_app_libraries.py
@@ -25,42 +25,40 @@
 import os
 import sys
 
+from ansys.tools.path import get_mechanical_path
 import pytest
 
 from ansys.mechanical.core.embedding import add_mechanical_python_libraries
-from ansys.tools.path import get_mechanical_path
 
 
 @pytest.mark.embedding
 def test_app_library(embedded_app):
     """Loads one of the libraries and calls a method."""
     _version = embedded_app.version
-    
+
     # Test with version as input
     exe = get_mechanical_path(_version)
     while os.path.basename(exe) != f"v{_version}":
         exe = os.path.dirname(exe)
-
+    exe = exe.replace("\\\\", "\\")
     location = os.path.join(exe, "Addins", "ACT", "libraries", "Mechanical")
     add_mechanical_python_libraries(_version)
-    print(sys.path)
-    print(location)
-    # assert location in sys.path
-    # sys.path.remove(location)
-    # assert location not in sys.path
+    assert location in sys.path
+    sys.path.remove(location)
+    assert location not in sys.path
 
-    # # Test with app as input
-    # add_mechanical_python_libraries(embedded_app)
-    # installdir = os.environ[f"AWP_ROOT{embedded_app.version}"]
-    # location = os.path.join(installdir, "Addins", "ACT", "libraries", "Mechanical")
-    # assert location in sys.path
+    # Test with app as input
+    add_mechanical_python_libraries(embedded_app)
+    installdir = os.environ[f"AWP_ROOT{embedded_app.version}"]
+    location = os.path.join(installdir, "Addins", "ACT", "libraries", "Mechanical")
+    assert location in sys.path
 
     # import mechanical library and test a method
 
-    # from mechanical import AnalysisTypeName
+    from mechanical import AnalysisTypeName
 
-    # analysis_name = AnalysisTypeName(0)
-    # assert analysis_name == "Static"
+    analysis_name = AnalysisTypeName(0)
+    assert analysis_name == "Static"
 
-    # sys.path.remove(location)
-    # assert location not in sys.path
+    sys.path.remove(location)
+    assert location not in sys.path

--- a/tests/embedding/test_app_libraries.py
+++ b/tests/embedding/test_app_libraries.py
@@ -25,7 +25,6 @@
 import os
 import sys
 
-from ansys.tools.path.path import _get_unified_install_base_for_version
 import pytest
 
 from ansys.mechanical.core.embedding import add_mechanical_python_libraries
@@ -34,10 +33,10 @@ from ansys.mechanical.core.embedding import add_mechanical_python_libraries
 @pytest.mark.embedding
 def test_app_library(embedded_app):
     """Loads one of the libraries and calls a method."""
-    add_mechanical_python_libraries(embedded_app.version)
-    install, _ = _get_unified_install_base_for_version(embedded_app.version)
-    location = os.path.join(install, "Addins", "ACT", "libraries", "Mechanical")
-    assert location in sys.path
+    add_mechanical_python_libraries(embedded_app)
+    app_installdir = os.environ[f"AWP_ROOT{embedded_app.version}"]
+    app_library_location = os.path.join(app_installdir, "Addins", "ACT", "libraries", "Mechanical")
+    assert app_library_location in sys.path
 
     # import mechanical library and test a method
 


### PR DESCRIPTION
fix `add_mechanical_python_libraries` to take the app itself rather than the version number.