### PR TITLE
fix: Display image and build info only for scheduled run

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -168,6 +168,7 @@ jobs:
           grep -q 'WB Initialize Done' <(timeout 60 tail -f log.txt)
 
       - name: Display info
+        if: github.event_name == 'schedule'
         id: capture_info
         run: |
           IMAGE_NAME=${{ env.DOCKER_PACKAGE }}:${{ matrix.mechanical-version }}

--- a/doc/changelog.d/746.fixed.md
+++ b/doc/changelog.d/746.fixed.md
@@ -1,0 +1,1 @@
+fix: Display image and build info only for scheduled run


### PR DESCRIPTION
solves issue on release workflow where we have multiple image