### PR TITLE
fix: upload coverage files only for latest stable version on release workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -201,6 +201,7 @@ jobs:
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v4
+        if: matrix.mechanical-version == needs.revn-variations.outputs.test_docker_image_version
         with:
           name: coverage-tests
           path: .cov
@@ -208,6 +209,7 @@ jobs:
 
       - name: Upload coverage results (as .coverage)
         uses: actions/upload-artifact@v4
+        if: matrix.mechanical-version == needs.revn-variations.outputs.test_docker_image_version
         with:
           name: coverage-file-tests
           path: .coverage

--- a/doc/changelog.d/748.fixed.md
+++ b/doc/changelog.d/748.fixed.md
@@ -1,0 +1,1 @@
+fix: upload coverage files only for latest stable version on release workflow


### PR DESCRIPTION
Release workflow runs the remote tests on 3 images which uploads coverage files with same name and causes below issue
https://github.com/ansys/pymechanical/actions/runs/9209141487/job/25333060420