### PR TITLE
MAINT: Delete the apt-get lists after installing packages

### DIFF
--- a/doc/changelog.d/750.changed.md
+++ b/doc/changelog.d/750.changed.md
@@ -1,0 +1,1 @@
+MAINT: Delete the apt-get lists after installing packages

--- a/docker/231/Dockerfile
+++ b/docker/231/Dockerfile
@@ -59,7 +59,9 @@ RUN apt-get update && apt-get install -y \
     xvfb \
     tini \
     ca-certificates\
-    libgomp1
+    libgomp1 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Copying files
 WORKDIR /install/
@@ -113,7 +115,7 @@ ENV ANSYS_VERSION=${VERSION} \
     ANS_WB_FORCE_EGL=1 \
     MECHANICAL_ON_DOCKER=TRUE
 
-# expose port for grpc
+# expose port for gRPC
 EXPOSE 10000
 
 # Set working directory

--- a/docker/232/Dockerfile
+++ b/docker/232/Dockerfile
@@ -59,7 +59,9 @@ RUN apt-get update && apt-get install -y \
     xvfb \
     tini \
     ca-certificates \
-    libgomp1
+    libgomp1 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Copying files
 WORKDIR /install/
@@ -91,7 +93,7 @@ ENV ANSYS_VERSION=${VERSION} \
     ANS_WB_FORCE_EGL=1 \
     MECHANICAL_ON_DOCKER=TRUE
 
-# expose port for grpc
+# expose port for gRPC
 EXPOSE 10000
 
 # Set working directory

--- a/docker/241/Dockerfile
+++ b/docker/241/Dockerfile
@@ -59,7 +59,9 @@ RUN apt-get update && apt-get install -y \
     xvfb \
     tini \
     ca-certificates \
-    libgomp1
+    libgomp1 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Copying files
 WORKDIR /install/
@@ -91,7 +93,7 @@ ENV ANSYS_VERSION=${VERSION} \
     ANS_WB_FORCE_EGL=1 \
     MECHANICAL_ON_DOCKER=TRUE
 
-# expose port for grpc
+# expose port for gRPC
 EXPOSE 10000
 
 # Set working directory


### PR DESCRIPTION
Cleaning up the apt cache and removing /var/lib/apt/lists helps keep the image size down. Since the RUN statement starts with apt-get update, the package cache will always be refreshed prior to apt-get install.

Clean up must be performed in the same RUN step, otherwise it will affect image size.