### PR TITLE
Doc: Add embedding api references

### DIFF
--- a/doc/changelog.d/758.added.md
+++ b/doc/changelog.d/758.added.md
@@ -1,0 +1,1 @@
+Doc: Add embedding api references

--- a/doc/source/api/embedding.rst
+++ b/doc/source/api/embedding.rst
@@ -1,0 +1,23 @@
+.. _ref_embedding:
+
+Embedding
+=========
+
+These class and methods provide embedding capability of Mechanical
+
+.. currentmodule:: ansys.mechanical.core.embedding
+
+.. autosummary::
+   :toctree: _autosummary
+
+
+   App
+   logger.Logger
+   add_mechanical_python_libraries
+   Transaction
+   global_variables
+   poster.Poster
+   warnings.connectwarnings
+   utils.sleep
+
+

--- a/doc/source/api/embedding.rst
+++ b/doc/source/api/embedding.rst
@@ -12,11 +12,11 @@ These class and methods provide embedding capability of Mechanical
 
 
    App
+   global_variables
+   Transaction
+   poster.Poster
    logger.Logger
    add_mechanical_python_libraries
-   Transaction
-   global_variables
-   poster.Poster
    warnings.connectwarnings
    utils.sleep
 

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -10,6 +10,7 @@ This section describes PyMechanical classes, functions, and attributes.
    :maxdepth: 2
    :hidden:
 
+   embedding
    helper
    pool
    logging
@@ -17,6 +18,7 @@ This section describes PyMechanical classes, functions, and attributes.
    path
 
 .. toctree::
+- :ref:`ref_embedding`
 - :ref:`ref_launcher_api`
 - :ref:`ref_pool_api`
 - :ref:`ref_logger_api`


### PR DESCRIPTION
Add Embedding API references in Documentation

![image](https://github.com/ansys/pymechanical/assets/26918585/210212ca-cd49-4c43-b03d-720c9c7ff8ad)
