### PR TITLE
Feat: Add option not to copy app data all the time

### DIFF
--- a/src/ansys/mechanical/core/embedding/appdata.py
+++ b/src/ansys/mechanical/core/embedding/appdata.py
@@ -38,14 +38,20 @@ class UniqueUserProfile:
         self._dry_run = dry_run
         self.initialize()
 
-    def initialize(self) -> None:
-        """Initialize the new profile location."""
+    def initialize(self, copy_profiles=True) -> None:
+        """
+        Initialize the new profile location.
+
+        Args:
+            copy_profiles (bool): If False, the copy_profiles method will be skipped.
+        """
         if self._dry_run:
             return
         if self.exists():
             self.cleanup()
         self.mkdirs()
-        self.copy_profiles()
+        if copy_profiles:
+            self.copy_profiles()
 
     def cleanup(self) -> None:
         """Cleanup unique user profile."""


### PR DESCRIPTION
As mentioned in issue https://github.com/ansys/pymechanical/issues/738. Provided an option not to copy profiles by default it will as the code used to