### PR TITLE
fix pythonnet issue

### DIFF
--- a/doc/changelog.d/772.fixed.md
+++ b/doc/changelog.d/772.fixed.md
@@ -1,0 +1,1 @@
+fix pythonnet issue

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -287,9 +287,14 @@ class App:
         return self._version
 
     def _subscribe(self):
-        self._subscribed = True
-        self.ExtAPI.Application.EventSource.OnAfterNew += self._on_after_new
-        self.ExtAPI.Application.EventSource.OnAfterDatabaseLoad += self._on_after_open
+        try:
+            # This will throw an error when using pythonnet because
+            # EventSource isn't defined on the IApplication interface
+            self.ExtAPI.Application.EventSource.OnAfterNew += self._on_after_new
+            self.ExtAPI.Application.EventSource.OnAfterDatabaseLoad += self._on_after_open
+            self._subscribed = True
+        except:
+            self._subscribed = False
 
     def _unsubscribe(self):
         if not self._subscribed:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,13 +176,15 @@ def mke_app_reset(request):
 
 _CHECK_PROCESS_RETURN_CODE = os.name == "nt"
 
+# set to true if you want to see all the subprocess stdout/stderr
+_PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE = False
 
 @pytest.fixture()
 def run_subprocess():
     def func(args, env=None, check: bool = None):
         if check is None:
             check = _CHECK_PROCESS_RETURN_CODE
-        stdout, stderr = ansys.mechanical.core.run._run(args, env, check)
+        stdout, stderr = ansys.mechanical.core.run._run(args, env, check, _PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE)
         return stdout, stderr
 
     return func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,12 +179,15 @@ _CHECK_PROCESS_RETURN_CODE = os.name == "nt"
 # set to true if you want to see all the subprocess stdout/stderr
 _PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE = False
 
+
 @pytest.fixture()
 def run_subprocess():
     def func(args, env=None, check: bool = None):
         if check is None:
             check = _CHECK_PROCESS_RETURN_CODE
-        stdout, stderr = ansys.mechanical.core.run._run(args, env, check, _PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE)
+        stdout, stderr = ansys.mechanical.core.run._run(
+            args, env, check, _PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE
+        )
         return stdout, stderr
 
     return func


### PR DESCRIPTION
This fixes the nightly runs issue. It's a weird failure mode...

I added the event handlers for updating the globals which doesn't work when running on pythonnet. Since this happens in the constructor, this will throw an exception and the atexit handler will be called, which also throws an exception. Apparently, this will cause the asyncio-based subprocess handling to hang. I'm not sure why this only seems to affect 242...