### PR TITLE
chore: bump add-license-headers version to 0.3.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     args: ["--ignore-words", "doc/styles/config/vocabularies/ANSYS/accept.txt", "-w"]
 
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.3.1
+  rev: v0.3.2
   hooks:
   - id: add-license-headers
     args:

--- a/doc/changelog.d/782.changed.md
+++ b/doc/changelog.d/782.changed.md
@@ -1,0 +1,1 @@
+chore: bump add-license-headers version to 0.3.2


### PR DESCRIPTION
Added recursion back to the add-license-headers hook