### PR TITLE
Feat: Add option for generating docs without examples

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -539,7 +539,7 @@ jobs:
           }
 
           # Make the html doc & validate results
-          make_doc html
+          make_doc html-noplot
 
           # Make the pdf doc & validate results
           make_doc pdf

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -539,7 +539,7 @@ jobs:
           }
 
           # Make the html doc & validate results
-          make_doc html-noplot
+          make_doc html
 
           # Make the pdf doc & validate results
           make_doc pdf

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -39,4 +39,4 @@ pdf:
 
 # generate docs without examples
 html-noplot:
-	@$(SPHINXBUILD) -D plot_gallery=0 -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -D plot_gallery=0 -b "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -39,4 +39,6 @@ pdf:
 
 # generate docs without examples
 html-noplot:
-	@$(SPHINXBUILD) -D plot_gallery=0 -b "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -D plot_gallery=0 -b html $(SOURCEDIR) $(BUILDDIR)/html $(SPHINXOPTS) $(O)
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -36,3 +36,7 @@ pdf:
 	@$(SPHINXBUILD) -M latex "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	cd $(BUILDDIR)/latex && latexmk -r latexmkrc -pdf *.tex -interaction=nonstopmode || true
 	(test -f $(BUILDDIR)/latex/*.pdf && echo pdf exists) || exit 1
+
+# generate docs without examples
+html-noplot:
+    @$(SPHINXBUILD) -D plot_gallery=0 -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -12,6 +12,7 @@ set BUILDDIR=_build
 set LINKCHECKDIR=\%BUILDDIR%\linkcheck
 
 if "%1" == "" goto help
+if "%1" == "html-noplot" goto html-noplot
 if "%1" == "clean" goto clean
 if "%1" == "pdf" goto pdf
 if "%1" == "linkcheck" goto linkcheck
@@ -30,6 +31,10 @@ if errorlevel 9009 (
 )
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:html-noplot
+%SPHINXBUILD% -D plot_gallery=0 -b html %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end
 
 :clean
@@ -57,4 +62,3 @@ goto end
 
 :end
 popd
-

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -34,7 +34,7 @@ if errorlevel 9009 (
 goto end
 
 :html-noplot
-%SPHINXBUILD% -D plot_gallery=0 -b html %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+%SPHINXBUILD% -D plot_gallery=0 -b html %SOURCEDIR% %BUILDDIR%/html %SPHINXOPTS% %O%
 goto end
 
 :clean


### PR DESCRIPTION
usage: ``.\doc\make.bat html-noplot``

This is helpful if you want to generate docs without having to run Mechanical for examples @ansys/pyansys-core 