### PR TITLE
fix: underline issue with changelog.rst section generation

### DIFF
--- a/doc/changelog.d/855.fixed.md
+++ b/doc/changelog.d/855.fixed.md
@@ -1,0 +1,1 @@
+fix: underline issue with changelog.rst section generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ package = "ansys.mechanical.core"
 directory = "doc/changelog.d"
 filename = "doc/source/changelog.rst"
 start_string = ".. towncrier release notes start\n"
-underlines = ["", "", ""]
 template = "doc/changelog.d/changelog_template.jinja"
 title_format = "`{version} <https://github.com/ansys/pymechanical/releases/tag/v{version}>`_ - {project_date}"
 issue_format = "`#{issue} <https://github.com/ansys/pymechanical/pull/{issue}>`_"


### PR DESCRIPTION
Closes #778 - Had to remove the `underlines` section with blank strings in order for the characters to appear under the section title