### PR TITLE
Refactor usd export

### DIFF
--- a/doc/changelog.d/858.fixed.md
+++ b/doc/changelog.d/858.fixed.md
@@ -1,0 +1,1 @@
+Refactor usd export

--- a/src/ansys/mechanical/core/embedding/viz/embedding_plotter.py
+++ b/src/ansys/mechanical/core/embedding/viz/embedding_plotter.py
@@ -72,6 +72,8 @@ def _get_nodes_and_coords(node: "Ansys.Mechanical.Scenegraph.Node"):
 def to_plotter(app: "ansys.mechanical.core.embedding.App"):
     """Convert the app's geometry to an ``ansys.tools.visualization_interface.Plotter`` instance."""
     plotter = Plotter()
+
+    # TODO - use get_scene from utils instead of looping over bodies directly here.
     for body in app.DataModel.GetObjectsByType(
         Ansys.Mechanical.DataModel.Enums.DataModelObjectCategory.Body
     ):

--- a/src/ansys/mechanical/core/embedding/viz/usd_converter.py
+++ b/src/ansys/mechanical/core/embedding/viz/usd_converter.py
@@ -89,7 +89,6 @@ def _convert_transform_node(
     Currently only supports transforms that contain a single tri tessellation node.
     """
     import clr
-
     clr.AddReference("Ansys.Mechanical.DataModel")
     clr.AddReference("Ansys.ACT.Interfaces")
 
@@ -105,7 +104,6 @@ def _convert_transform_node(
 def load_into_usd_stage(app: "ansys.mechanical.core.embedding.App", stage: Usd.Stage) -> None:
     """Load mechanical scene into usd stage `stage`."""
     import clr
-
     clr.AddReference("Ansys.Mechanical.DataModel")
     clr.AddReference("Ansys.ACT.Interfaces")
 

--- a/src/ansys/mechanical/core/embedding/viz/usd_converter.py
+++ b/src/ansys/mechanical/core/embedding/viz/usd_converter.py
@@ -116,6 +116,7 @@ def _convert_attribute_node(
     clr.AddReference("Ansys.ACT.Interfaces")
 
     import Ansys  # isort: skip
+
     child_node = node.Child
     color = node.Property(Ansys.Mechanical.Scenegraph.ScenegraphIntAttributes.Color)
     _convert_transform_node(child_node, stage, path, bgr_to_rgb_tuple(color))

--- a/src/ansys/mechanical/core/embedding/viz/usd_converter.py
+++ b/src/ansys/mechanical/core/embedding/viz/usd_converter.py
@@ -122,11 +122,10 @@ def _convert_attribute_node(
     _convert_transform_node(child_node, stage, path, bgr_to_rgb_tuple(color))
 
 
-def load_into_usd_stage(app: "ansys.mechanical.core.embedding.App", stage: Usd.Stage) -> None:
+def load_into_usd_stage(scene: "Ansys.Mechanical.Scenegraph.GroupNode", stage: Usd.Stage) -> None:
     """Load mechanical scene into usd stage `stage`."""
     root_prim = UsdGeom.Xform.Define(stage, "/root")
 
-    scene = get_scene(app)
     for child in scene.Children:
         child: "Ansys.Mechanical.Scenegraph.AttributeNode" = child
         child_path = root_prim.GetPath().AppendPath(child.Tag)
@@ -136,7 +135,8 @@ def load_into_usd_stage(app: "ansys.mechanical.core.embedding.App", stage: Usd.S
 def to_usd_stage(app: "ansys.mechanical.core.embedding.App", name: str) -> Usd.Stage:
     """Convert mechanical scene to new usd stage and return it."""
     stage = Usd.Stage.CreateNew(name)
-    load_into_usd_stage(app, stage)
+    scene = get_scene(app)
+    load_into_usd_stage(scene, stage)
     return stage
 
 

--- a/src/ansys/mechanical/core/embedding/viz/usd_converter.py
+++ b/src/ansys/mechanical/core/embedding/viz/usd_converter.py
@@ -109,7 +109,8 @@ def _convert_attribute_node(
 ) -> None:
     """Add a Usd Prim of the child node with the given attributes node.
 
-    Currently only supports color attributes"""
+    Currently only supports color attributes.
+    """
     import clr
 
     clr.AddReference("Ansys.Mechanical.DataModel")

--- a/src/ansys/mechanical/core/embedding/viz/utils.py
+++ b/src/ansys/mechanical/core/embedding/viz/utils.py
@@ -64,7 +64,7 @@ def get_nodes_and_coords(tri_tessellation: "Ansys.Mechanical.Scenegraph.TriTesse
 def get_scene(
     app: "ansys.mechanical.core.embedding.App",
 ) -> "Ansys.Mechanical.Scenegraph.GroupNode":
-    """Get the scene of the model"""
+    """Get the scene of the model."""
     import clr
 
     clr.AddReference("Ansys.Mechanical.DataModel")

--- a/test.py
+++ b/test.py
@@ -1,5 +1,4 @@
 import ansys.mechanical.core as mech
-
 import ansys.mechanical.core.embedding.viz.usd_converter as usd_converter
 
 app = mech.App(version=251, db_file=r"C:\Users\mkoubaa\Desktop\sanderson.mechdat")

--- a/test.py
+++ b/test.py
@@ -1,0 +1,7 @@
+import ansys.mechanical.core as mech
+
+import ansys.mechanical.core.embedding.viz.usd_converter as usd_converter
+
+app = mech.App(version=251, db_file=r"C:\Users\mkoubaa\Desktop\sanderson.mechdat")
+
+usd_converter.to_usd_file(app, "D:\\sanderson2.usda")

--- a/test.py
+++ b/test.py
@@ -1,6 +1,0 @@
-import ansys.mechanical.core as mech
-import ansys.mechanical.core.embedding.viz.usd_converter as usd_converter
-
-app = mech.App(version=251, db_file=r"C:\Users\mkoubaa\Desktop\sanderson.mechdat")
-
-usd_converter.to_usd_file(app, "D:\\sanderson2.usda")


### PR DESCRIPTION
Separate getting the mechanical scene from converting that scene to USD. Because mechanical isn't threadsafe, getting the scene must be done on mechanical's main thread, while converting to USD can be done on any thread.