### PR TITLE
DOCS: Fix doc layout

### DIFF
--- a/doc/changelog.d/888.documentation.md
+++ b/doc/changelog.d/888.documentation.md
@@ -1,0 +1,1 @@
+Fix doc layout

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -198,7 +198,7 @@ html_theme_options = {
     "show_breadcrumbs": True,
     "collapse_navigation": True,
     "use_edit_page_button": True,
-    "header_links_before_dropdown": 7,  # number of links before the dropdown menu
+    "header_links_before_dropdown": 5,  # number of links before the dropdown menu
     "additional_breadcrumbs": [
         ("PyAnsys", "https://docs.pyansys.com/"),
     ],


### PR DESCRIPTION
fix section with only 5 items.

currently there are 7 items

![image](https://github.com/user-attachments/assets/d8288ba8-4d59-413b-9c6f-74de454f438f)


