### PR TITLE
FEAT: Add method to execute script from file for embedding

### DIFF
--- a/doc/changelog.d/902.added.md
+++ b/doc/changelog.d/902.added.md
@@ -1,0 +1,1 @@
+Add method to execute script from file for embedding

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -236,6 +236,13 @@ class App:
             raise Exception(error_msg)
         return script_result.Value
 
+    def execute_script_from_file(self, file_path=None):
+        """Execute the given script from file with the internal IronPython engine."""
+        text_file = open(file_path, "r", encoding="utf-8")
+        data = text_file.read()
+        text_file.close()
+        return self.execute_script(data)
+
     def plotter(self) -> None:
         """Return ``ansys.tools.visualization_interface.Plotter`` object."""
         if not HAS_ANSYS_VIZ:

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -323,3 +323,21 @@ def test_app_execute_script(embedded_app):
     with pytest.raises(Exception):
         # This will throw an exception since no module named test available
         embedded_app.execute_script("import test")
+
+
+@pytest.mark.embedding
+def test_app_execute_script_from_file(embedded_app, rootdir, printer):
+    """Test execute_script_from_file method."""
+    embedded_app.update_globals(globals())
+
+    printer("Running run_python_error.py")
+    error_script_path = os.path.join(rootdir, "tests", "scripts", "run_python_error.py")
+    with pytest.raises(Exception) as exc_info:
+        # This will throw an exception since no module named test available
+        embedded_app.execute_script_from_file(error_script_path)
+    assert "name 'get_myname' is not defined" in str(exc_info.value)
+
+    printer("Running run_python_success.py")
+    succes_script_path = os.path.join(rootdir, "tests", "scripts", "run_python_success.py")
+    result = embedded_app.execute_script_from_file(succes_script_path)
+    assert result == "test"


### PR DESCRIPTION
Leverage `execute_script` method for executing scripts from file