### PR TITLE
fix: documentation links

### DIFF
--- a/doc/changelog.d/911.fixed.md
+++ b/doc/changelog.d/911.fixed.md
@@ -1,0 +1,1 @@
+documentation links

--- a/doc/source/links.rst
+++ b/doc/source/links.rst
@@ -19,7 +19,8 @@
 .. _Chapter 7: https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/corp/%%VERSION%%/en/installation/win_silent.html
 
 .. # Mechanical related
-.. _ACT API Reference Guide: https://developer.ansys.com/docs/mechanical-scripting-interface/api/ansys/mechanical/stubs/v241/index.md #TODO this should be update to 241 when 24r2 api ref gets released
+.. _Mechanical scripting interface: https://developer.ansys.com/docs/mechanical-scripting-interface/api/index.md
+.. _ACT API Reference Guide: https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/corp/v242/en/act_ref/act_ref.html
 .. _Mechanical API known issues and limitations: https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/corp/%%VERSION%%/en/act_script/mech_apis_KIL.html?q=known%20issues
 .. _ACT known issues and limitations: https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/corp/%%VERSION%%/en/act_dev/act_dev_knownissues.html
 .. _Ansys Mechanical: https://www.ansys.com/products/structures/ansys-mechanical


### PR DESCRIPTION
Fix the `ACT API Reference Guide` link and add the `Mechanical scripting interface` link for documentation references