### PR TITLE
fix: Warning for multiple version

### DIFF
--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -239,7 +239,7 @@ class App:
         if script_result.Error is not None:
             error_msg += f": {script_result.Error.Message}"
             raise Exception(error_msg)
-        return str(script_result.Value)
+        return script_result.Value
 
     def execute_script_from_file(self, file_path=None):
         """Execute the given script from file with the internal IronPython engine."""

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -239,7 +239,7 @@ class App:
         if script_result.Error is not None:
             error_msg += f": {script_result.Error.Message}"
             raise Exception(error_msg)
-        return script_result.Value
+        return str(script_result.Value)
 
     def execute_script_from_file(self, file_path=None):
         """Execute the given script from file with the internal IronPython engine."""

--- a/src/ansys/mechanical/core/embedding/initializer.py
+++ b/src/ansys/mechanical/core/embedding/initializer.py
@@ -92,7 +92,7 @@ def _get_latest_default_version() -> int:
     latest_version = max(versions_found)
 
     if len(awp_roots) > 1:
-        raise Warning(
+        warnings.warn(
             f"Multiple versions of Mechanical found! Using latest version {latest_version} ..."
         )
 


### PR DESCRIPTION
use the ``warnings`` module to issue a warning instead of raising it as an exception.
