### PR TITLE
fix: bandit warnings

### DIFF
--- a/doc/changelog.d/950.fixed.md
+++ b/doc/changelog.d/950.fixed.md
@@ -1,0 +1,1 @@
+bandit warnings

--- a/src/ansys/mechanical/core/embedding/background.py
+++ b/src/ansys/mechanical/core/embedding/background.py
@@ -102,5 +102,5 @@ class BackgroundApp:
             try:
                 utils.sleep(40)
             except:
-                raise Exception("BackgroundApp cannot sleep.")
+                raise Exception("BackgroundApp cannot sleep.")  # pragma: no cover
         BackgroundApp.__stopped = True

--- a/src/ansys/mechanical/core/embedding/background.py
+++ b/src/ansys/mechanical/core/embedding/background.py
@@ -102,5 +102,5 @@ class BackgroundApp:
             try:
                 utils.sleep(40)
             except:
-                pass
+                raise Exception("BackgroundApp cannot sleep.")
         BackgroundApp.__stopped = True

--- a/src/ansys/mechanical/core/embedding/ui.py
+++ b/src/ansys/mechanical/core/embedding/ui.py
@@ -22,7 +22,10 @@
 """Run Mechanical UI from Python."""
 
 from pathlib import Path
-from subprocess import Popen
+
+# Subprocess is needed to launch the GUI and clean up the process on close.
+# Excluding bandit check.
+from subprocess import Popen  # nosec
 import sys
 import tempfile
 import typing
@@ -113,7 +116,7 @@ class UILauncher:
         if not self._dry_run:
             # The subprocess that uses ansys-mechanical to launch the GUI of the temporary
             # mechdb file
-            process = Popen(args)
+            process = Popen(args)  # nosec
             return process
         else:
             # Return a string containing the args
@@ -136,7 +139,7 @@ class UILauncher:
             # Open a subprocess to remove the temporary mechdb file and folder when the process ends
             Popen(
                 [sys.executable, cleanup_script, str(process.pid), temp_mechdb_path]
-            )  # pragma: no cover
+            )  # pragma: no cover # nosec
 
 
 def _is_saved(app: "ansys.mechanical.core.embedding.App") -> bool:

--- a/src/ansys/mechanical/core/embedding/ui.py
+++ b/src/ansys/mechanical/core/embedding/ui.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 # Subprocess is needed to launch the GUI and clean up the process on close.
 # Excluding bandit check.
-from subprocess import Popen  # nosec
+from subprocess import Popen  # nosec: B404
 import sys
 import tempfile
 import typing
@@ -116,7 +116,7 @@ class UILauncher:
         if not self._dry_run:
             # The subprocess that uses ansys-mechanical to launch the GUI of the temporary
             # mechdb file
-            process = Popen(args)  # nosec
+            process = Popen(args)  # nosec: B603
             return process
         else:
             # Return a string containing the args
@@ -139,7 +139,7 @@ class UILauncher:
             # Open a subprocess to remove the temporary mechdb file and folder when the process ends
             Popen(
                 [sys.executable, cleanup_script, str(process.pid), temp_mechdb_path]
-            )  # pragma: no cover # nosec
+            )  # pragma: no cover # nosec: B603
 
 
 def _is_saved(app: "ansys.mechanical.core.embedding.App") -> bool:

--- a/src/ansys/mechanical/core/embedding/ui.py
+++ b/src/ansys/mechanical/core/embedding/ui.py
@@ -116,7 +116,7 @@ class UILauncher:
         if not self._dry_run:
             # The subprocess that uses ansys-mechanical to launch the GUI of the temporary
             # mechdb file
-            process = Popen(args)  # nosec: B603
+            process = Popen(args)  # nosec: B603 # pragma: no cover
             return process
         else:
             # Return a string containing the args

--- a/src/ansys/mechanical/core/launcher.py
+++ b/src/ansys/mechanical/core/launcher.py
@@ -23,10 +23,11 @@
 """Launch Mechanical in batch or UI mode."""
 import errno
 import os
-import subprocess
+
+# Subprocess is needed to start the backend. Excluding bandit check.
+import subprocess  # nosec
 
 from ansys.mechanical.core import LOG
-from ansys.mechanical.core.misc import is_windows
 
 
 class MechanicalLauncher:
@@ -90,17 +91,16 @@ class MechanicalLauncher:
         env_variables = self.__get_env_variables()
         args_list = self.__get_commandline_args()
 
-        shell_value = False
-
-        if is_windows():
-            shell_value = True
-
         LOG.info(f"Starting the process using {args_list}.")
         if self.verbose:
             command = " ".join(args_list)
             print(f"Running {command}.")
 
-        process = subprocess.Popen(args_list, shell=shell_value, env=env_variables)
+        process = subprocess.Popen(
+            args_list,
+            stdout=subprocess.PIPE,
+            env=env_variables,
+        )  # nosec
         LOG.info(f"Started the process:{process} using {args_list}.")
 
     @staticmethod

--- a/src/ansys/mechanical/core/launcher.py
+++ b/src/ansys/mechanical/core/launcher.py
@@ -25,7 +25,7 @@ import errno
 import os
 
 # Subprocess is needed to start the backend. Excluding bandit check.
-import subprocess  # nosec
+import subprocess  # nosec: B404
 
 from ansys.mechanical.core import LOG
 

--- a/src/ansys/mechanical/core/launcher.py
+++ b/src/ansys/mechanical/core/launcher.py
@@ -100,7 +100,7 @@ class MechanicalLauncher:
             args_list,
             stdout=subprocess.PIPE,
             env=env_variables,
-        )  # nosec
+        )  # nosec: B603
         LOG.info(f"Started the process:{process} using {args_list}.")
 
     @staticmethod


### PR DESCRIPTION
- Change `pass` to `raise Exception`
- Add `# no sec` lines to subprocesses where the arguments are known/valid
- Remove `shell=True` from subprocess