### PR TITLE
fix: stubs CLI test

### DIFF
--- a/doc/changelog.d/952.fixed.md
+++ b/doc/changelog.d/952.fixed.md
@@ -1,1 +1,1 @@
-subs_cli test
+subs cli test

--- a/doc/changelog.d/952.fixed.md
+++ b/doc/changelog.d/952.fixed.md
@@ -1,0 +1,1 @@
+subs_cli test

--- a/doc/changelog.d/952.fixed.md
+++ b/doc/changelog.d/952.fixed.md
@@ -1,1 +1,1 @@
-subs cli test
+stubs CLI test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ markers = [
     "remote_session_launch: tests that launch Mechanical and work with gRPC server inside it",
     "remote_session_connect: tests that connect to Mechanical and work with gRPC server inside it",
     "minimum_version(num): tests that run if ansys-version is greater than or equal to the minimum version provided",
+    "version_range(min_revn, max_revn): tests that run if ansys-version is in the range of the minimum and maximum revision numbers inclusive.",
     "windows_only: tests that run if the testing platform is on Windows",
     "linux_only: tests that run if the testing platform is on Linux",
     "cli: tests for the Command Line Interface",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ markers = [
     "remote_session_launch: tests that launch Mechanical and work with gRPC server inside it",
     "remote_session_connect: tests that connect to Mechanical and work with gRPC server inside it",
     "minimum_version(num): tests that run if ansys-version is greater than or equal to the minimum version provided",
-    "version_range(min_revn, max_revn): tests that run if ansys-version is in the range of the minimum and maximum revision numbers inclusive.",
+    "version_range(min_revn,max_revn): tests that run if ansys-version is in the range of the minimum and maximum revision numbers inclusive.",
     "windows_only: tests that run if the testing platform is on Windows",
     "linux_only: tests that run if the testing platform is on Linux",
     "cli: tests for the Command Line Interface",

--- a/src/ansys/mechanical/core/ide_config.py
+++ b/src/ansys/mechanical/core/ide_config.py
@@ -25,11 +25,56 @@
 import json
 import os
 from pathlib import Path
+import site
 import sys
-import sysconfig
 
 import ansys.tools.path as atp
 import click
+
+
+def get_stubs_location():
+    """Find the ansys-mechanical-stubs installation location in site-packages.
+
+    Returns
+    -------
+    pathlib.Path
+        The path to the ansys-mechanical-stubs installation in site-packages.
+    """
+    site_packages_path = ""
+    site_packages = site.getsitepackages()
+
+    for loc in site_packages:
+        if ("site-packages" in loc) and (sys.prefix in loc):
+            site_packages_path = loc
+
+    if site_packages_path:
+        # Get the stubs location
+        stubs_location = Path(site_packages_path) / "ansys" / "mechanical" / "stubs"
+        return stubs_location
+
+    raise Exception("Could not retrieve the location of the ansys-mechanical-stubs package.")
+
+
+def get_stubs_versions(stubs_location: Path):
+    """Retrieve the revision numbers in ansys-mechanical-stubs.
+
+    Parameters
+    ----------
+    pathlib.Path
+        The path to the ansys-mechanical-stubs installation in site-packages.
+
+    Returns
+    -------
+    list
+        The list containing minimum and maximum versions in the ansys-mechanical-stubs package.
+    """
+    # Get revision numbers in stubs folder
+    revns = [
+        int(revision[1:])
+        for revision in os.listdir(stubs_location)
+        if os.path.isdir(os.path.join(stubs_location, revision)) and revision.startswith("v")
+    ]
+    return revns
 
 
 def _vscode_impl(
@@ -65,9 +110,7 @@ def _vscode_impl(
         settings_json = current_dir / ".vscode" / "settings.json"
 
     # Location where the stubs are installed -> .venv/Lib/site-packages, for example
-    stubs_location = (
-        Path(sysconfig.get_paths()["purelib"]) / "ansys" / "mechanical" / "stubs" / f"v{revision}"
-    )
+    stubs_location = get_stubs_location() / f"v{revision}"
 
     # The settings to add to settings.json for autocomplete to work
     settings_json_data = {
@@ -105,8 +148,12 @@ def _cli_impl(
         The Mechanical revision number. For example, "242".
         If unspecified, it finds the default Mechanical version from ansys-tools-path.
     """
+    # Get the ansys-mechanical-stubs install location
+    stubs_location = get_stubs_location()
+    # Get all revision numbers available in ansys-mechanical-stubs
+    revns = get_stubs_versions(stubs_location)
     # Check the IDE and raise an exception if it's not VS Code
-    if revision < 241 or revision > 242:
+    if revision < min(revns) or revision > max(revns):
         raise Exception(f"PyMechanical Stubs are not available for {revision}")
     elif ide != "vscode":
         raise Exception(f"{ide} is not supported at the moment.")

--- a/src/ansys/mechanical/core/ide_config.py
+++ b/src/ansys/mechanical/core/ide_config.py
@@ -25,6 +25,7 @@
 import json
 import os
 from pathlib import Path
+import re
 import site
 import sys
 
@@ -40,16 +41,14 @@ def get_stubs_location():
     pathlib.Path
         The path to the ansys-mechanical-stubs installation in site-packages.
     """
-    site_packages_path = ""
     site_packages = site.getsitepackages()
+    prefix_path = sys.prefix.replace("\\", "\\\\")
+    site_packages_regex = re.compile(f"{prefix_path}.*site-packages$")
+    site_packages_paths = list(filter(site_packages_regex.match, site_packages))
 
-    for loc in site_packages:
-        if ("site-packages" in loc) and (sys.prefix in loc):
-            site_packages_path = loc
-
-    if site_packages_path:
+    if len(site_packages_paths) == 1:
         # Get the stubs location
-        stubs_location = Path(site_packages_path) / "ansys" / "mechanical" / "stubs"
+        stubs_location = Path(site_packages_paths[0]) / "ansys" / "mechanical" / "stubs"
         return stubs_location
 
     raise Exception("Could not retrieve the location of the ansys-mechanical-stubs package.")

--- a/src/ansys/mechanical/core/ide_config.py
+++ b/src/ansys/mechanical/core/ide_config.py
@@ -106,10 +106,12 @@ def _cli_impl(
         If unspecified, it finds the default Mechanical version from ansys-tools-path.
     """
     # Check the IDE and raise an exception if it's not VS Code
-    if ide == "vscode":
-        return _vscode_impl(target, revision)
-    else:
+    if revision < 241 or revision > 242:
+        raise Exception(f"PyMechanical Stubs are not available for {revision}")
+    elif ide != "vscode":
         raise Exception(f"{ide} is not supported at the moment.")
+    else:
+        return _vscode_impl(target, revision)
 
 
 @click.command()
@@ -154,14 +156,11 @@ def cli(ide: str, target: str, revision: int) -> None:
         $ ansys-mechanical-ideconfig --ide vscode --target user --revision 242
 
     """
-    if revision < 241 or revision > 242:
-        raise Exception(f"PyMechanical Stubs are not available for {revision}")
-    else:
-        exe = atp.get_mechanical_path(allow_input=False, version=revision)
-        version = atp.version_from_path("mechanical", exe)
+    exe = atp.get_mechanical_path(allow_input=False, version=revision)
+    version = atp.version_from_path("mechanical", exe)
 
-        return _cli_impl(
-            ide,
-            target,
-            version,
-        )
+    return _cli_impl(
+        ide,
+        target,
+        version,
+    )

--- a/src/ansys/mechanical/core/ide_config.py
+++ b/src/ansys/mechanical/core/ide_config.py
@@ -154,11 +154,14 @@ def cli(ide: str, target: str, revision: int) -> None:
         $ ansys-mechanical-ideconfig --ide vscode --target user --revision 242
 
     """
-    exe = atp.get_mechanical_path(allow_input=False, version=revision)
-    version = atp.version_from_path("mechanical", exe)
+    if revision < 241 or revision > 242:
+        raise Exception(f"PyMechanical Stubs are not available for {revision}")
+    else:
+        exe = atp.get_mechanical_path(allow_input=False, version=revision)
+        version = atp.version_from_path("mechanical", exe)
 
-    return _cli_impl(
-        ide,
-        target,
-        version,
-    )
+        return _cli_impl(
+            ide,
+            target,
+            version,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,11 +385,24 @@ def pytest_addoption(parser):
 def pytest_collection_modifyitems(config, items):
     """Skips tests marked minimum_version if ansys-version is less than mark argument."""
     for item in items:
+        # Skip tests that are less than the minimum version
         if "minimum_version" in item.keywords:
             revn = [mark.args[0] for mark in item.iter_markers(name="minimum_version")]
             if int(config.getoption("--ansys-version")) < revn[0]:
                 skip_versions = pytest.mark.skip(
                     reason=f"Requires ansys-version greater than or equal to {revn[0]}."
+                )
+                item.add_marker(skip_versions)
+
+        # Skip tests that are outside of the provided version range. For example,
+        # @pytest.mark.version_range(241,242)
+        if "version_range" in item.keywords:
+            revns = [mark.args for mark in item.iter_markers(name="version_range")][0]
+            ansys_version = int(config.getoption("--ansys-version"))
+
+            if (ansys_version < revns[0]) or (ansys_version > revns[1]):
+                skip_versions = pytest.mark.skip(
+                    reason=f"Requires ansys-version in the range {revns[0]} to {revns[1]}."
                 )
                 item.add_marker(skip_versions)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -273,20 +273,33 @@ def get_stubs_location(revision: int) -> Path:
 @pytest.mark.cli
 def test_ideconfig_cli_ide_exception(capfd, pytestconfig):
     """Test IDE configuration raises an exception for anything but vscode."""
-    revision = pytestconfig.getoption("ansys_version")
+    revision = int(pytestconfig.getoption("ansys_version"))
     with pytest.raises(Exception):
         ideconfig_cli_impl(
             ide="pycharm",
             target="user",
-            revision=242,
+            revision=revision,
         )
+
+
+@pytest.mark.cli
+def test_ideconfig_cli_version_exception(capfd, pytestconfig):
+    """Test IDE configuration raises an exception for anything but vscode."""
+    revision = int(pytestconfig.getoption("ansys_version"))
+    if revision < 241 or revision > 242:
+        with pytest.raises(Exception):
+            ideconfig_cli_impl(
+                ide="vscode",
+                target="user",
+                revision=revision,
+            )
 
 
 @pytest.mark.cli
 def test_ideconfig_cli_user_settings(capfd, pytestconfig):
     """Test the IDE configuration prints correct information for user settings."""
     # Set the revision number
-    revision = pytestconfig.getoption("ansys_version")
+    revision = int(pytestconfig.getoption("ansys_version"))
 
     # Run the IDE configuration command for the user settings type
     ideconfig_cli_impl(
@@ -303,15 +316,18 @@ def test_ideconfig_cli_user_settings(capfd, pytestconfig):
     settings_json = get_settings_location()
     stubs_location = get_stubs_location(revision)
 
-    assert f"Update {settings_json} with the following information" in out
-    assert str(stubs_location) in out
+    if revision < 241 or revision > 242:
+        assert f"PyMechanical Stubs are not available for {revision}." in out
+    else:
+        assert f"Update {settings_json} with the following information" in out
+        assert str(stubs_location) in out
 
 
 @pytest.mark.cli
 def test_ideconfig_cli_workspace_settings(capfd, pytestconfig):
     """Test the IDE configuration prints correct information for workplace settings."""
     # Set the revision number
-    revision = pytestconfig.getoption("ansys_version")
+    revision = int(pytestconfig.getoption("ansys_version"))
 
     # Run the IDE configuration command
     ideconfig_cli_impl(
@@ -328,10 +344,15 @@ def test_ideconfig_cli_workspace_settings(capfd, pytestconfig):
     settings_json = Path.cwd() / ".vscode" / "settings.json"
     stubs_location = get_stubs_location(revision)
 
-    # Assert the correct settings.json file and stubs location is in the output
-    assert f"Update {settings_json} with the following information" in out
-    assert str(stubs_location) in out
-    assert "Please ensure the .vscode folder is in the root of your project or repository" in out
+    if revision < 241 or revision > 242:
+        assert f"PyMechanical Stubs are not available for {revision}." in out
+    else:
+        # Assert the correct settings.json file and stubs location is in the output
+        assert f"Update {settings_json} with the following information" in out
+        assert str(stubs_location) in out
+        assert (
+            "Please ensure the .vscode folder is in the root of your project or repository" in out
+        )
 
 
 @pytest.mark.cli
@@ -339,7 +360,7 @@ def test_ideconfig_cli_workspace_settings(capfd, pytestconfig):
 def test_ideconfig_venv(test_env, run_subprocess, rootdir, pytestconfig):
     """Test the IDE configuration location when a virtual environment is active."""
     # Set the revision number
-    revision = pytestconfig.getoption("ansys_version")
+    revision = int(pytestconfig.getoption("ansys_version"))
 
     # Install pymechanical
     subprocess.check_call(
@@ -364,8 +385,11 @@ def test_ideconfig_venv(test_env, run_subprocess, rootdir, pytestconfig):
     # Decode stdout and fix extra backslashes in paths
     stdout = stdout.decode().replace("\\\\", "\\")
 
-    # Assert virtual environment is in the stdout
-    assert ".test_env" in stdout
+    if revision < 241 or revision > 242:
+        assert f"PyMechanical Stubs are not available for {revision}." in stdout
+    else:
+        # Assert virtual environment is in the stdout
+        assert ".test_env" in stdout
 
 
 @pytest.mark.cli
@@ -373,7 +397,7 @@ def test_ideconfig_venv(test_env, run_subprocess, rootdir, pytestconfig):
 def test_ideconfig_default(test_env, run_subprocess, rootdir, pytestconfig):
     """Test the IDE configuration location when no arguments are supplied."""
     # Get the revision number
-    revision = pytestconfig.getoption("ansys_version")
+    revision = int(pytestconfig.getoption("ansys_version"))
     # Set part of the settings.json path
     settings_json_fragment = Path("Code") / "User" / "settings.json"
 
@@ -394,6 +418,9 @@ def test_ideconfig_default(test_env, run_subprocess, rootdir, pytestconfig):
     # Decode stdout and fix extra backslashes in paths
     stdout = stdout.decode().replace("\\\\", "\\")
 
-    assert revision in stdout
-    assert str(settings_json_fragment) in stdout
-    assert ".test_env" in stdout
+    if revision < 241 or revision > 242:
+        assert f"PyMechanical Stubs are not available for {revision}." in stdout
+    else:
+        assert revision in stdout
+        assert str(settings_json_fragment) in stdout
+        assert ".test_env" in stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -372,7 +372,7 @@ def test_ideconfig_venv(test_env, run_subprocess, rootdir):
 def test_ideconfig_default(test_env, run_subprocess, rootdir, pytestconfig):
     """Test the IDE configuration location when no arguments are supplied."""
     # Get the revision number
-    revision = pytestconfig.getoption("ansys_version")
+    revision = 242
     # Set part of the settings.json path
     settings_json_fragment = Path("Code") / "User" / "settings.json"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -421,6 +421,6 @@ def test_ideconfig_default(test_env, run_subprocess, rootdir, pytestconfig):
     if revision < 241 or revision > 242:
         assert f"PyMechanical Stubs are not available for {revision}." in stdout
     else:
-        assert revision in stdout
+        assert str(revision) in stdout
         assert str(settings_json_fragment) in stdout
         assert ".test_env" in stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -335,10 +335,10 @@ def test_ideconfig_cli_workspace_settings(capfd):
 
 @pytest.mark.cli
 @pytest.mark.python_env
-def test_ideconfig_venv(test_env, run_subprocess, rootdir):
+def test_ideconfig_venv(test_env, run_subprocess, rootdir, pytestconfig):
     """Test the IDE configuration location when a virtual environment is active."""
     # Set the revision number
-    revision = 242
+    revision = pytestconfig.getoption("ansys_version")
 
     # Install pymechanical
     subprocess.check_call(
@@ -372,7 +372,7 @@ def test_ideconfig_venv(test_env, run_subprocess, rootdir):
 def test_ideconfig_default(test_env, run_subprocess, rootdir, pytestconfig):
     """Test the IDE configuration location when no arguments are supplied."""
     # Get the revision number
-    revision = 242
+    revision = pytestconfig.getoption("ansys_version")
     # Set part of the settings.json path
     settings_json_fragment = Path("Code") / "User" / "settings.json"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -271,8 +271,9 @@ def get_stubs_location(revision: int) -> Path:
 
 
 @pytest.mark.cli
-def test_ideconfig_cli_ide_exception(capfd):
+def test_ideconfig_cli_ide_exception(capfd, pytestconfig):
     """Test IDE configuration raises an exception for anything but vscode."""
+    revision = pytestconfig.getoption("ansys_version")
     with pytest.raises(Exception):
         ideconfig_cli_impl(
             ide="pycharm",
@@ -282,10 +283,10 @@ def test_ideconfig_cli_ide_exception(capfd):
 
 
 @pytest.mark.cli
-def test_ideconfig_cli_user_settings(capfd):
+def test_ideconfig_cli_user_settings(capfd, pytestconfig):
     """Test the IDE configuration prints correct information for user settings."""
     # Set the revision number
-    revision = 242
+    revision = pytestconfig.getoption("ansys_version")
 
     # Run the IDE configuration command for the user settings type
     ideconfig_cli_impl(
@@ -307,10 +308,10 @@ def test_ideconfig_cli_user_settings(capfd):
 
 
 @pytest.mark.cli
-def test_ideconfig_cli_workspace_settings(capfd):
+def test_ideconfig_cli_workspace_settings(capfd, pytestconfig):
     """Test the IDE configuration prints correct information for workplace settings."""
     # Set the revision number
-    revision = 241
+    revision = pytestconfig.getoption("ansys_version")
 
     # Run the IDE configuration command
     ideconfig_cli_impl(


### PR DESCRIPTION
Tests run fine on 242, but fails in candidate because cli_impl takes mechanical path from local installed path. hence `ansys-mechanical-ideconfig` will throw exception.

- [x] Add check for available stubs version
- [x] Add necessary test