### PR TITLE
FEAT: Update private app data creation and add tests

### DIFF
--- a/doc/changelog.d/986.added.md
+++ b/doc/changelog.d/986.added.md
@@ -1,1 +1,1 @@
-Add test for private app data creation
+Update private app data creation and add tests

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -148,8 +148,9 @@ class App:
         configuration = kwargs.get("config", _get_default_addin_configuration())
 
         if private_appdata:
+            copy_profile = kwargs.get("copy_profile", True)
             new_profile_name = f"PyMechanical-{os.getpid()}"
-            profile = UniqueUserProfile(new_profile_name)
+            profile = UniqueUserProfile(new_profile_name, copy_profile)
             profile.update_environment(os.environ)
             atexit.register(_cleanup_private_appdata, profile)
 

--- a/src/ansys/mechanical/core/embedding/appdata.py
+++ b/src/ansys/mechanical/core/embedding/appdata.py
@@ -31,26 +31,27 @@ import warnings
 class UniqueUserProfile:
     """Create Unique User Profile (for AppData)."""
 
-    def __init__(self, profile_name: str, dry_run: bool = False):
+    def __init__(self, profile_name: str, copy_profile: bool = True, dry_run: bool = False):
         """Initialize UniqueUserProfile class."""
         self._default_profile = os.path.expanduser("~")
         self._location = os.path.join(self._default_profile, "PyMechanical-AppData", profile_name)
         self._dry_run = dry_run
+        self.copy_profile = copy_profile
         self.initialize()
 
-    def initialize(self, copy_profiles=True) -> None:
+    def initialize(self) -> None:
         """
         Initialize the new profile location.
 
         Args:
-            copy_profiles (bool): If False, the copy_profiles method will be skipped.
+            copy_profile (bool): If False, the copy_profile method will be skipped.
         """
         if self._dry_run:
             return
         if self.exists():
             self.cleanup()
         self.mkdirs()
-        if copy_profiles:
+        if self.copy_profile:
             self.copy_profiles()
 
     def cleanup(self) -> None:

--- a/src/ansys/mechanical/core/run.py
+++ b/src/ansys/mechanical/core/run.py
@@ -172,7 +172,7 @@ def _cli_impl(
     profile: UniqueUserProfile = None
     if private_appdata:
         new_profile_name = f"Mechanical-{os.getpid()}"
-        profile = UniqueUserProfile(new_profile_name, DRY_RUN)
+        profile = UniqueUserProfile(new_profile_name, dry_run=DRY_RUN)
         profile.update_environment(env)
 
     if not DRY_RUN:

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -240,37 +240,6 @@ def test_warning_message(test_env, pytestconfig, run_subprocess, rootdir):
 
 
 @pytest.mark.embedding_scripts
-@pytest.mark.python_env
-def test_private_appdata(pytestconfig, run_subprocess, rootdir):
-    """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
-
-    version = pytestconfig.getoption("ansys_version")
-    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
-
-    run_subprocess([sys.executable, embedded_py, version, "True", "Set"])
-    process, stdout, stderr = run_subprocess([sys.executable, embedded_py, version, "True", "Run"])
-    stdout = stdout.decode()
-    assert "ShowTriad value is True" in stdout
-
-
-@pytest.mark.embedding_scripts
-@pytest.mark.python_env
-def test_normal_appdata(pytestconfig, run_subprocess, rootdir):
-    """Test embedded instance saves ShowTriad value using a test-scoped Python environment."""
-    version = pytestconfig.getoption("ansys_version")
-
-    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
-
-    run_subprocess([sys.executable, embedded_py, version, "False", "Set"])
-    process, stdout, stderr = run_subprocess([sys.executable, embedded_py, version, "False", "Run"])
-    run_subprocess([sys.executable, embedded_py, version, "False", "Reset"])
-
-    stdout = stdout.decode()
-    # Assert ShowTriad was set to False for regular embedded session
-    assert "ShowTriad value is False" in stdout
-
-
-@pytest.mark.embedding_scripts
 def test_building_gallery(pytestconfig, run_subprocess, rootdir):
     """Test for building gallery check.
 

--- a/tests/embedding/test_appdata.py
+++ b/tests/embedding/test_appdata.py
@@ -65,7 +65,7 @@ def test_normal_appdata(pytestconfig, run_subprocess, rootdir):
 
 @pytest.mark.embedding
 def test_uniqueprofile_creation():
-    """Test user profile is copied when copy_profile is ``True`` and is not copied when ``False``."""
+    """Test profile is copied when copy_profile is ``True`` and is not copied when ``False``."""
     folder_to_check = Path("AppData") / "Local" / "Ansys" if os.name == "nt" else ".mw"
 
     # Create private app data without copying profiles

--- a/tests/embedding/test_appdata.py
+++ b/tests/embedding/test_appdata.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Embedding tests related to app data"""
+
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+from ansys.mechanical.core.embedding.appdata import UniqueUserProfile
+
+
+@pytest.mark.embedding_scripts
+@pytest.mark.python_env
+def test_private_appdata(pytestconfig, run_subprocess, rootdir):
+    """Test embedded instance does not save ShowTriad using a test-scoped Python environment."""
+
+    version = pytestconfig.getoption("ansys_version")
+    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
+
+    run_subprocess([sys.executable, embedded_py, version, "True", "Set"])
+    process, stdout, stderr = run_subprocess([sys.executable, embedded_py, version, "True", "Run"])
+    stdout = stdout.decode()
+    assert "ShowTriad value is True" in stdout
+
+
+@pytest.mark.embedding_scripts
+@pytest.mark.python_env
+def test_normal_appdata(pytestconfig, run_subprocess, rootdir):
+    """Test embedded instance saves ShowTriad value using a test-scoped Python environment."""
+    version = pytestconfig.getoption("ansys_version")
+
+    embedded_py = os.path.join(rootdir, "tests", "scripts", "run_embedded_app.py")
+
+    run_subprocess([sys.executable, embedded_py, version, "False", "Set"])
+    process, stdout, stderr = run_subprocess([sys.executable, embedded_py, version, "False", "Run"])
+    run_subprocess([sys.executable, embedded_py, version, "False", "Reset"])
+
+    stdout = stdout.decode()
+    # Assert ShowTriad was set to False for regular embedded session
+    assert "ShowTriad value is False" in stdout
+
+
+@pytest.mark.embedding
+def test_uniqueprofile_creation():
+
+    folder_to_check = os.path.join("AppData", "Local", "Ansys") if os.name == "nt" else ".mw"
+
+    # Create private app data without copying profiles
+    private_data2 = UniqueUserProfile(profile_name="test1", copy_profile=False)
+    assert not os.path.exists(os.path.join(private_data2.location, folder_to_check))
+
+    # Check if location is same with same profile name
+    private_data1 = UniqueUserProfile(profile_name="test1")
+    assert private_data1.location == private_data2.location
+
+    # check if folder exists after copying profiles
+    assert os.path.exists(os.path.join(private_data1.location, folder_to_check))
+
+    # Create new profile
+    private_data3 = UniqueUserProfile(profile_name="test2")
+    assert private_data2.location != private_data3.location
+
+
+@pytest.mark.embedding
+def test_uniqueprofile_env():
+    profile = UniqueUserProfile("test_env")
+    env = {}
+    platforms = ["win32", "linux"]
+
+    for platform in platforms:
+        with mock.patch.object(sys, "platform", platform):
+            profile.update_environment(env)
+
+    if platform == "win32":
+        env["USERPROFILE"] = profile.location
+        env["APPDATA"] = os.path.join(profile.location, "AppData/Roaming")
+        env["LOCALAPPDATA"] = os.path.join(profile.location, "AppData/Local")
+        env["TMP"] = os.path.join(profile.location, "AppData/Local/Temp")
+        env["TEMP"] = os.path.join(profile.location, "AppData/Local/Temp")
+    else:
+        env["HOME"] = profile.location
+
+
+@pytest.mark.embedding
+def test_uniqueprofile_dryrun():
+    profile = UniqueUserProfile("test_dry_run", dry_run=True)
+    assert not os.path.exists(profile.location)

--- a/tests/embedding/test_appdata.py
+++ b/tests/embedding/test_appdata.py
@@ -23,9 +23,10 @@
 """Embedding tests related to app data"""
 
 import os
+from pathlib import Path
 import sys
 from unittest import mock
-from pathlib import Path
+
 import pytest
 
 from ansys.mechanical.core.embedding.appdata import UniqueUserProfile
@@ -96,7 +97,7 @@ def test_uniqueprofile_env():
 
     if platform == "win32":
         env["USERPROFILE"] = profile.location
-        env["APPDATA"] =Path(profile.location) / "AppData" / "Roaming"
+        env["APPDATA"] = Path(profile.location) / "AppData" / "Roaming"
         env["LOCALAPPDATA"] = Path(profile.location) / "AppData" / "Local"
         env["TMP"] = Path(profile.location) / "AppData" / "Local" / "Temp"
         env["TEMP"] = Path(profile.location) / "AppData" / "Local " / "Temp"

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -32,7 +32,7 @@ import ansys.mechanical.core as pymechanical
 def launch_app(version, private_appdata):
     """Launch embedded instance of app."""
     # Configuration.configure(level=logging.DEBUG, to_stdout=True, base_directory=None)
-    app = pymechanical.App(version=version, private_appdata=private_appdata)
+    app = pymechanical.App(version=version, private_appdata=private_appdata, copy_profile=True)
     return app
 
 


### PR DESCRIPTION
- Update private app data creation to have copy_profile option
 eg: ``App(private_appdata=True, copy_profile=False)``
- Move appdata tests to new file and add tests for UniqueUserProfile creation,
~45% increase in coverage