### PR TITLE
fix: Process return code

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -358,7 +358,7 @@ jobs:
     name: Embedding scripts testing and coverage
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [smoke-tests, revn-variations]
+    needs: [revn-variations]
     container:
       image: ${{ needs.revn-variations.outputs.test_container }}
       options: --entrypoint /bin/bash

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -358,7 +358,7 @@ jobs:
     name: Embedding scripts testing and coverage
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [revn-variations]
+    needs: [smoke-tests, revn-variations]
     container:
       image: ${{ needs.revn-variations.outputs.test_container }}
       options: --entrypoint /bin/bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,7 @@ def mke_app_reset(request):
     EMBEDDED_APP.new()
 
 
-_CHECK_PROCESS_RETURN_CODE = os.name == "nt"
+_CHECK_PROCESS_RETURN_CODE = True
 
 # set to True if you want to see all the subprocess stdout/stderr
 _PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,8 +176,6 @@ def mke_app_reset(request):
     EMBEDDED_APP.new()
 
 
-_CHECK_PROCESS_RETURN_CODE = True
-
 # set to True if you want to see all the subprocess stdout/stderr
 _PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE = False
 
@@ -186,7 +184,7 @@ _PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE = False
 def run_subprocess():
     def func(args, env=None, check: bool = None):
         if check is None:
-            check = _CHECK_PROCESS_RETURN_CODE
+            check = True
         process, output = ansys.mechanical.core.run._run(
             args, env, check, _PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,7 +187,7 @@ def run_subprocess(pytestconfig):
         if check is None:
             check = True
             if os.name != "nt":
-                if version < 251:
+                if int(version) < 251:
                     check = False
         process, output = ansys.mechanical.core.run._run(
             args, env, check, _PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,10 +181,14 @@ _PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE = False
 
 
 @pytest.fixture()
-def run_subprocess():
+def run_subprocess(pytestconfig):
+    version = pytestconfig.getoption("ansys_version")
     def func(args, env=None, check: bool = None):
         if check is None:
             check = True
+            if os.name != "nt":
+                if version < 251:
+                    check = False
         process, output = ansys.mechanical.core.run._run(
             args, env, check, _PRINT_SUBPROCESS_OUTPUT_TO_CONSOLE
         )

--- a/tests/embedding/test_logger.py
+++ b/tests/embedding/test_logger.py
@@ -57,14 +57,16 @@ def _run_embedding_log_test(
     embedded_py = os.path.join(rootdir, "tests", "scripts", "embedding_log_test.py")
 
     subprocess_pass_expected = pass_expected
-    if pass_expected == True and os.name != "nt" and int(version) < 251:
-        subprocess_pass_expected = False
+    if pass_expected == True:
+        if os.name != "nt" and int(version) < 251:
+            subprocess_pass_expected = False
 
-    process, stdout, stderr = run_subprocess(
+    _, stdout, stderr = run_subprocess(
         [sys.executable, embedded_py, version, testname],
         _get_env_without_logging_variables(),
         subprocess_pass_expected,
     )
+
     if not subprocess_pass_expected:
         stdout = stdout.decode()
         _assert_success(stdout, pass_expected)


### PR DESCRIPTION
There is no crash on shutdown for 251+, but there was still some tests that allowed subprocesses without exceptions to throw a nonzero result. I modified this to only be the case for <251.

Here's the pipeline run for 251: https://github.com/ansys/pymechanical/actions/runs/12652827509