### PR TITLE
docs: Clarify support guidelines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,8 +124,23 @@ on Windows and Linux for version 2023 R2 and later. Here is an example:
    app.update_globals(globals())
    project_dir = DataModel.Project.ProjectDirectory
 
-Documentation and issues
-------------------------
+How to report issues
+--------------------
+
+If you encounter any issues or limitations with PyMechanical that hinder your work, please create
+an issue or discussion so our team can address them promptly:
+
+* `PyMechanical Issues <https://github.com/ansys/pymechanical/issues>`_: Report bugs and request new features.
+* `PyMechanical Discussions <https://github.com/ansys/pymechanical/discussions>`_: Post questions, share ideas, and get community feedback.
+
+For issues pertaining to `Mechanical scripting <https://mechanical.docs.pyansys.com/version/stable/user_guide_scripting/index.html>`_,
+please make a post on the `Developer Portal <https://forum.ansys.com/categories/structures>`_.
+
+If you have general questions about PyAnsys or are unsure which repository to place an issue in,
+email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+
+Documentation resources
+-----------------------
 
 Documentation for the latest stable release of PyMechanical is hosted at `PyMechanical documentation
 <https://mechanical.docs.pyansys.com/>`_.
@@ -138,13 +153,6 @@ You can also `view <https://cheatsheets.docs.pyansys.com/pymechanical_cheat_shee
 `download <https://cheatsheets.docs.pyansys.com/pymechanical_cheat_sheet.pdf>`_ the
 PyMechanical cheat sheet. This one-page reference provides syntax rules and commands
 for using PyMechanical.
-
-On the `PyMechanical Issues <https://github.com/ansys/pymechanical/issues>`_ page,
-you can create issues to report bugs and request new features. On the `PyMechanical Discussions
-<https://github.com/ansys/pymechanical/discussions>`_ page or the `Discussions <https://discuss.ansys.com/>`_
-page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback.
-
-To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 Testing and development
 -----------------------

--- a/doc/changelog.d/1061.documentation.md
+++ b/doc/changelog.d/1061.documentation.md
@@ -1,0 +1,1 @@
+Clarify support guidelines

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,6 +21,9 @@ from ansys.mechanical.core.embedding.initializer import SUPPORTED_MECHANICAL_EMB
 # necessary when building the sphinx gallery
 pymechanical.BUILDING_GALLERY = True
 
+# Whether or not to build the cheatsheet
+BUILD_CHEATSHEET = True
+
 # suppress annoying matplotlib bug
 warnings.filterwarnings(
     "ignore",
@@ -57,9 +60,11 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
     "sphinx_design",
-    "sphinx_gallery.gen_gallery",
     "sphinxemoji.sphinxemoji",
 ]
+
+if pymechanical.BUILDING_GALLERY:
+    extensions.append("sphinx_gallery.gen_gallery")
 
 # Intersphinx mapping
 intersphinx_mapping = {
@@ -207,13 +212,15 @@ html_theme_options = {
             "icon": "fa fa-comment fa-fw",
         },
     ],
-    "cheatsheet": {
-        "file": "cheatsheet/cheat_sheet.qmd",
-        "title": "PyMechanical cheat sheet",
-    },
     "ansys_sphinx_theme_autoapi": {"project": project, "templates": "_templates/autoapi"},
     "navigation_depth": 10,
 }
+
+if BUILD_CHEATSHEET:
+    html_theme_options["cheatsheet"] = {
+        "file": "cheatsheet/cheat_sheet.qmd",
+        "title": "PyMechanical cheat sheet",
+    }
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/doc/source/kil/index.rst
+++ b/doc/source/kil/index.rst
@@ -43,7 +43,7 @@ an issue or discussion so our team can address them promptly:
 * `PyMechanical Discussions <https://github.com/ansys/pymechanical/discussions>`_: Post questions, share ideas, and get community feedback.
 
 For issues pertaining to `Mechanical scripting <https://mechanical.docs.pyansys.com/version/stable/user_guide_scripting/index.html>`_,
-please make a post on the `Developer Portal <https://forum.ansys.com/categories/structures>`_.
+please make a post on the `Ansys Developer Forum for Mechanical <https://discuss.ansys.com/categories/structures>`_.
 
 If you have general questions about PyAnsys or are unsure which repository to place an issue in,
 email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.

--- a/doc/source/kil/index.rst
+++ b/doc/source/kil/index.rst
@@ -36,8 +36,14 @@ Ansys recommends that you always use the latest version of both to achieve the b
 Support
 =======
 
-If you encounter any issues or limitations that hinder your work, please contact our support team immediately.
-We are committed to providing timely assistance to ensure your projects run smoothly.
+If you encounter any issues or limitations with PyMechanical that hinder your work, please create
+an issue or discussion so our team can address them promptly:
 
-- Mechanical : `Discussion forum <https://discuss.ansys.com/categories/structures>`_
-- PyMechanical : Create issue in github or contact `pyansys team <pyansys_support_>`_
+* `PyMechanical Issues <https://github.com/ansys/pymechanical/issues>`_: Report bugs and request new features.
+* `PyMechanical Discussions <https://github.com/ansys/pymechanical/discussions>`_: Post questions, share ideas, and get community feedback.
+
+For issues pertaining to `Mechanical scripting <https://mechanical.docs.pyansys.com/version/stable/user_guide_scripting/index.html>`_,
+please make a post on the `Developer Portal <https://forum.ansys.com/categories/structures>`_.
+
+If you have general questions about PyAnsys or are unsure which repository to place an issue in,
+email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.

--- a/doc/source/user_guide_scripting/index.rst
+++ b/doc/source/user_guide_scripting/index.rst
@@ -23,11 +23,19 @@ You could already perform scripting of Mechanical with Python from inside
 Mechanical. PyMechanical leverages the same APIs but allows you to run your
 automation from outside Mechanical.
 
-.. note::
+For comprehensive information on these APIs, refer to the following documentation:
 
-   For comprehensive information on these APIs, see the `Scripting in Mechanical Guide`_ in the
-   Ansys Help portal, the `Mechanical scripting interface APIs`_ in the Developer Portal, or the
-   `Mechanical API Documentation`_.
+PyMechanical documentation:
+
+* `Mechanical API Documentation`_ - Lists Mechanical APIs that can be used with PyMechanical.
+
+Developer portal:
+
+* `Mechanical scripting interface APIs`_ - Contains the same information as the `Mechanical API Documentation`_ but is located on the developer portal.
+
+ACT API Reference Guide:
+
+* `ACT API Reference Guide`_ - Provides descriptions of the objects, methods, and properties for all namespaces.
 
 Recording
 ---------
@@ -89,9 +97,3 @@ When running scripts inside of Mechanical, you can access the APIs via these ent
 
 You also have access to several types and namespaces that are included in the scripting scope but are not available
 from those entry points.
-
-Additional resources
---------------------
-
-The `ACT API Reference Guide`_
-provides descriptions of the objects, methods, and properties for all namespaces.


### PR DESCRIPTION
- If someone is having issues with PyMechanical, they should create an issue or discussion in PyMechanical
- If someone has a question about Mechanical scripting, they should create a post on the developer portal

- Also added booleans to conf.py to turn on/off building the cheatsheet or examples. By default, it builds the cheatsheet & examples

Addresses #473 