### PR TITLE
docs: Add "what's new" fragment for the globals parameter in App

### DIFF
--- a/doc/changelog.d/1096.documentation.md
+++ b/doc/changelog.d/1096.documentation.md
@@ -1,0 +1,1 @@
+Add "what's new" fragment for the globals parameter in App

--- a/doc/changelog.d/whatsnew.yml
+++ b/doc/changelog.d/whatsnew.yml
@@ -1,4 +1,29 @@
 fragments:
+- title: Globals parameter in the embedded app
+  version: 0.11.14
+  content: |
+    The ``globals`` parameter of the `App <api/ansys/mechanical/core/embedding/app/App.html>`_
+    class is used to update the global variables. This parameter is optional and interchangeable
+    with `app.update_globals(globals()) <api/ansys/mechanical/core/embedding/app/App.html#App.update_globals>`_.
+
+    Using the ``globals`` parameter:
+
+    .. code:: python
+
+        from ansys.mechanical.core import App
+
+        # Initialize the app and update globals
+        app = App(globals=globals())
+
+    Using the ``update_globals`` method:
+
+    .. code:: python
+
+        from ansys.mechanical.core import App
+
+        # Initialize the app and update globals
+        app = App()
+        app.update_globals(globals())
 
 - title: Launch GUI
   version: 0.11.8


### PR DESCRIPTION
As the title says

![globals_doc](https://github.com/user-attachments/assets/43810699-af78-4d55-9167-cf0c1f70be7e)
