### PR TITLE
docs: Adjust globals documentation

### DIFF
--- a/doc/changelog.d/1098.documentation.md
+++ b/doc/changelog.d/1098.documentation.md
@@ -1,0 +1,1 @@
+Fix typo for remote session documentation.

--- a/doc/changelog.d/whatsnew.yml
+++ b/doc/changelog.d/whatsnew.yml
@@ -5,6 +5,8 @@ fragments:
     The ``globals`` parameter of the `App <api/ansys/mechanical/core/embedding/app/App.html>`_
     class is used to update the global variables. This parameter is optional and interchangeable
     with `app.update_globals(globals()) <api/ansys/mechanical/core/embedding/app/App.html#App.update_globals>`_.
+    To exclude enums from the global variables, use ``app.update_globals(globals(), False)``.
+    See the `globals <user_guide_embedding/globals.html>`_ page for more information.
 
     Using the ``globals`` parameter:
 
@@ -24,6 +26,16 @@ fragments:
         # Initialize the app and update globals
         app = App()
         app.update_globals(globals())
+
+    Using the ``update_globals`` method excluding enums from global variables:
+
+    .. code:: python
+
+        from ansys.mechanical.core import App
+
+        # Initialize the app and update globals
+        app = App()
+        app.update_globals(globals(), False)
 
 - title: Launch GUI
   version: 0.11.8

--- a/doc/source/cheatsheet/cheat_sheet.qmd
+++ b/doc/source/cheatsheet/cheat_sheet.qmd
@@ -147,20 +147,16 @@ mechanical.exit(force=True)
 # Load a Mechanical embedded instance
 
 
-## Start an instance of App
+## Start an instance of App with global API entry points
 ```{python}
 #| eval: false
 from ansys.mechanical.core import App
-app = App(version=251)
-print(app)
-```
-Extract and merge global API entry points:
-```{python}
-#| eval: false
 
+# Create an instance of the app
 # Extract global API entry points from Mechanical
 # Merge them into your Python global variables
-app.update_globals(globals())
+app = App(version=251, globals=globals())
+print(app)
 ```
 Access entry points from Python:
 ```{python}
@@ -178,7 +174,6 @@ Import a file and print the count of bodies
 
 file = r"D:\\Workdir\\bracket.mechdb"
 app.open(file)
-app.update_globals(globals())
 allbodies = Model.GetChildren(
   DataModelObjectCategory.Body, True)
 print(allbodies.Count)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,10 +19,10 @@ import ansys.mechanical.core as pymechanical
 from ansys.mechanical.core.embedding.initializer import SUPPORTED_MECHANICAL_EMBEDDING_VERSIONS
 
 # necessary when building the sphinx gallery
-pymechanical.BUILDING_GALLERY = True
+pymechanical.BUILDING_GALLERY = False  # True
 
 # Whether or not to build the cheatsheet
-BUILD_CHEATSHEET = True
+BUILD_CHEATSHEET = False  # True
 
 # suppress annoying matplotlib bug
 warnings.filterwarnings(
@@ -316,6 +316,7 @@ linkcheck_ignore = [
     "../api/*",  # Remove this after release 0.10.12
     "api/*",
     "path.html",
+    "user_guide_embedding/*",
 ]
 
 linkcheck_anchors = False

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,7 +22,7 @@ from ansys.mechanical.core.embedding.initializer import SUPPORTED_MECHANICAL_EMB
 pymechanical.BUILDING_GALLERY = True
 
 # Whether or not to build the cheatsheet
-BUILD_CHEATSHEET = False  # True
+BUILD_CHEATSHEET = True
 
 # suppress annoying matplotlib bug
 warnings.filterwarnings(

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,7 +19,7 @@ import ansys.mechanical.core as pymechanical
 from ansys.mechanical.core.embedding.initializer import SUPPORTED_MECHANICAL_EMBEDDING_VERSIONS
 
 # necessary when building the sphinx gallery
-pymechanical.BUILDING_GALLERY = False  # True
+pymechanical.BUILDING_GALLERY = True
 
 # Whether or not to build the cheatsheet
 BUILD_CHEATSHEET = False  # True

--- a/doc/source/user_guide_embedding/globals.rst
+++ b/doc/source/user_guide_embedding/globals.rst
@@ -7,27 +7,39 @@ When using Mechanical scripting APIs (in either Mechanical's graphical user inte
 sending scripts to a remote session of Mechanical), there are many global variables that are
 by default usable from Python. Some of these are API entry points, like those discussed in
 :ref:`ref_user_guide_scripting`, while others are types and namespaces that are used by the
-scripting APIs. Examples of those are the ``Quantity``, ``Transaction`` class or the ``DataModel`` entry point.
+scripting APIs. Examples of those are the ``Quantity``, ``Transaction`` class or the ``DataModel``
+entry point.
 
-Embedding Mechanical into Python is as simple as constructing an application object. This can
-not automatically change the global variables available to the Python scope that constructed
-it. As a utility, a function that adds the API entry points is available. To use it, run the
-following code:
+To add these global variables to the Python scope, create an instance of the ``App`` class
+with the ``globals`` argument set to the Python global variables:
+
+.. code:: python
+
+   from ansys.mechanical.core import App
+
+   # The following line creates an instance of the app, extracts the global API entry points,
+   # and merges them into your Python global variables.
+   app = App(globals=globals())
+
+Alternatively, you can use the ``update_globals`` method of the ``App`` class to update the global
+variables:
 
 .. code:: python
 
    from ansys.mechanical.core import App
 
    app = App()
-   # The following line extracts the global API entry points and merges them into your global
-   # Python global variables.
    app.update_globals(globals())
 
-Some enum types are available when scripting inside of mechanical, such as ``SelectionTypeEnum``
+Some enum types are available when scripting inside of Mechanical, such as ``SelectionTypeEnum``
 or ``LoadDefineBy``. Because these number in the thousands, by default, these enums are
 included in these global variables. To avoid including them, set the second argument of
-``update_globals`` to False.
+``update_globals`` to False. This option is only available for the ``update_globals`` method,
+not for the ``globals`` argument of the ``App`` class:
 
 .. code:: python
 
+   from ansys.mechanical.core import App
+
+   app = App()
    app.update_globals(globals(), False)

--- a/doc/source/user_guide_embedding/index.rst
+++ b/doc/source/user_guide_embedding/index.rst
@@ -70,8 +70,7 @@ The scripting occurs inside Mechanical's command line interface. For instance, c
 
   from ansys.mechanical.core import App
 
-  app = App()
-  app.update_globals(globals())
+  app = App(globals=globals())
   ns = DataModel.Project.Model.AddNamedSelection()
   ns.Name = "Jarvis"
 

--- a/doc/source/user_guide_session/index.rst
+++ b/doc/source/user_guide_session/index.rst
@@ -47,7 +47,7 @@ to select the version of the product to launch.
         exec_file=exec_file_path, batch=False, cleanup_on_exit=False
     )
 
-If ``batch`` option is set ``True`` the Mechanical launches without GUI. The ``cleanup_on_exit``
+If ``batch`` option is set to ``True`` Mechanical is launched without GUI. The ``cleanup_on_exit``
 option decides whether product exits at the end of the PyMechanical script or not.
 
 .. note::


### PR DESCRIPTION
- Clarify when to use ``app.update_globals(globals())`` vs. ``app = App(globals=globals())`` (If you want to exclude enums in global vars, you should use ``app.update_globals(globals(), False)``
- Update cheatsheet with globals parameter