### PR TITLE
FEAT: Add rpyc option in `launch_mechanical`

### DIFF
--- a/doc/changelog.d/1096.documentation.md
+++ b/doc/changelog.d/1096.documentation.md
@@ -1,0 +1,1 @@
+Add "what's new" fragment for the globals parameter in App

--- a/doc/changelog.d/whatsnew.yml
+++ b/doc/changelog.d/whatsnew.yml
@@ -1,4 +1,29 @@
 fragments:
+- title: Globals parameter in the embedded app
+  version: 0.11.14
+  content: |
+    The ``globals`` parameter of the `App <api/ansys/mechanical/core/embedding/app/App.html>`_
+    class is used to update the global variables. This parameter is optional and interchangeable
+    with `app.update_globals(globals()) <api/ansys/mechanical/core/embedding/app/App.html#App.update_globals>`_.
+
+    Using the ``globals`` parameter:
+
+    .. code:: python
+
+        from ansys.mechanical.core import App
+
+        # Initialize the app and update globals
+        app = App(globals=globals())
+
+    Using the ``update_globals`` method:
+
+    .. code:: python
+
+        from ansys.mechanical.core import App
+
+        # Initialize the app and update globals
+        app = App()
+        app.update_globals(globals())
 
 - title: Launch GUI
   version: 0.11.8

--- a/src/ansys/mechanical/core/embedding/rpc/client.py
+++ b/src/ansys/mechanical/core/embedding/rpc/client.py
@@ -33,7 +33,7 @@ from ansys.mechanical.core.mechanical import DEFAULT_CHUNK_SIZE
 class Client:
     """Client for connecting to Mechanical services."""
 
-    def __init__(self, host: str, port: int, timeout: float = 120.0):
+    def __init__(self, host: str, port: int, timeout: float = 120.0, cleanup_on_exit=True):
         """Initialize the client.
 
         Parameters
@@ -55,6 +55,7 @@ class Client:
         self.connection = None
         self.root = None
         self._connect()
+        self._cleanup_on_exit = cleanup_on_exit
 
     def __getattr__(self, attr):
         """Get attribute from the root object."""
@@ -235,3 +236,11 @@ class Client:
         self.service_exit()
         self.connection.close()
         print("Disconnected from server")
+
+    def __del__(self):  # pragma: no cover
+        """Clean up on exit."""
+        if self._cleanup_on_exit:
+            try:
+                self.exit()
+            except Exception as e:
+                print(f"Failed to exit cleanly: {e}")

--- a/src/ansys/mechanical/core/mechanical.py
+++ b/src/ansys/mechanical/core/mechanical.py
@@ -30,7 +30,7 @@ import glob
 import os
 import pathlib
 import socket
-import subprocess
+import subprocess  # nosec: B404
 import sys
 import threading
 import time
@@ -1979,7 +1979,7 @@ server.start()
     try:
         embedded_server = subprocess.Popen(
             [sys.executable, "-c", server_script, str(port), str(_version)], env=env_copy
-        )
+        )  # nosec: B603
     except:
         raise RuntimeError("Unable to start the embedded server.")
 

--- a/src/ansys/mechanical/core/mechanical.py
+++ b/src/ansys/mechanical/core/mechanical.py
@@ -2048,7 +2048,7 @@ def launch_mechanical(
     cleanup_on_exit=True,
     version=None,
     keep_connection_alive=True,
-    rpc_type="grpc",
+    backend="mechanical",
 ) -> Mechanical:
     """Start Mechanical locally.
 
@@ -2131,8 +2131,9 @@ def launch_mechanical(
     keep_connection_alive : bool, optional
         Whether to keep the gRPC connection alive by running a background thread
         and making dummy calls for remote connections. The default is ``True``.
-    rpc_type : str, optional
-        Type of RPC to use. The default is ``"grpc"``. The other option is ``"rpyc"``.
+    backend : str, optional
+        Type of RPC to use. The default is ``"mechanical"`` which uses grpc.
+        The other option is ``"python"`` which uses RPyC.
 
     Returns
     -------
@@ -2286,7 +2287,7 @@ def launch_mechanical(
         "additional_envs": additional_envs,
     }
 
-    if rpc_type == "grpc":
+    if backend == "mechanical":
         try:
             port = launch_grpc(port=port, verbose=verbose_mechanical, **start_parm)
             start_parm["local"] = True
@@ -2304,7 +2305,7 @@ def launch_mechanical(
         except Exception as exception:  # pragma: no cover
             # pass
             raise exception
-    elif rpc_type == "rpyc":
+    elif backend == "python":
         port = launch_rpyc(port=port, **start_parm)
         from ansys.mechanical.core.embedding.rpc.client import Client
 


### PR DESCRIPTION
`launch_mechanical` now provides two rpc options such as `grpc` ( `backend = 'mechanical'`) and `rpyc`( `backend = 'python'`) . By default, it is `grpc`
It can be used as given below.
```python
import ansys.mechanical.core as pymechanical

mechanical = pymechanical.launch_mechanical(backend="python")
print(mechanical)
```
with `rpyc` option mechanical exists when python code completes.
with cleanup_on_exit option disabled , user can still use another client to connect the mechanical which is alive.

```python
import ansys.mechanical.core as pymechanical

mechanical = pymechanical.launch_mechanical(backend="python", cleanup_on_exit=False)
```