### PR TITLE
fix: Add exception to the enum importer file if the app isn't initialized

### DIFF
--- a/src/ansys/mechanical/core/embedding/enum_importer.py
+++ b/src/ansys/mechanical/core/embedding/enum_importer.py
@@ -25,6 +25,12 @@
 A useful subset of what is imported by
 Ansys Inc/v{NNN}/ACT/apis/Mechanical.py
 """
+
+from ansys.mechanical.core.embedding.app import is_initialized
+
+if not is_initialized():
+    raise Exception("Enums cannot be imported until the embedded app is initialized.")
+
 import clr
 
 clr.AddReference("Ansys.Mechanical.DataModel")


### PR DESCRIPTION
As the title says