### PR TITLE
fix: add workaround for windows store

### DIFF
--- a/doc/changelog.d/1153.fixed.md
+++ b/doc/changelog.d/1153.fixed.md
@@ -1,0 +1,1 @@
+add workaround for windows store

--- a/src/ansys/mechanical/core/embedding/initializer.py
+++ b/src/ansys/mechanical/core/embedding/initializer.py
@@ -137,7 +137,7 @@ def __windows_store_workaround(version: int) -> None:
         return
 
     # Nothing to do if it isn't a windows store application
-    if r"AppData\Local\Programs\Python" not in sys.executable:
+    if r"Microsoft\WindowsApps" not in sys.executable:
         return
 
     root = os.environ[f"AWP_ROOT{version}"]

--- a/src/ansys/mechanical/core/embedding/initializer.py
+++ b/src/ansys/mechanical/core/embedding/initializer.py
@@ -136,11 +136,11 @@ def __windows_store_workaround(version: int) -> None:
     version : int
         The version of Mechanical to set the DLL paths for.
     """
-    # Nothing to do on linux
+    # Nothing to do on Linux
     if os.name != "nt":
         return
 
-    # Nothing to do if it isn't a windows store application
+    # Nothing to do if it isn't a Windows store application
     if r"Microsoft\WindowsApps" not in sys.executable:
         return
 
@@ -151,18 +151,25 @@ def __windows_store_workaround(version: int) -> None:
         awp_root / "aisol" / "bin" / "winx64",
         awp_root / "Framework" / "bin" / "Win64",
     ]
-    # Add paths to the IntelCompiler, IntelMKL, hdf5, and qt DLLs for 2024R2 and 2025R1
-    if version == 242 or version == 251:
-        # Set the path to the tp directory within the AWP_ROOTXYZ directory
-        awp_root_tp = awp_root / "tp"
-        # Set the qt version based on the version of Mechanical
-        qt_version = "5.15.16" if version == 242 else "5.15.17"
+    # Set the path to the tp directory within the AWP_ROOTXYZ directory
+    awp_root_tp = awp_root / "tp"
+    # Add paths to the IntelCompiler, IntelMKL, HDF5, and Qt DLLs for 2024R2 and 2025R1
+    if version == 242:
         paths.extend(
             [
                 awp_root_tp / "IntelCompiler" / "2023.1.0" / "winx64",
                 awp_root_tp / "IntelMKL" / "2023.1.0" / "winx64",
                 awp_root_tp / "hdf5" / "1.12.2" / "winx64",
-                awp_root_tp / "qt" / qt_version / "winx64" / "bin",
+                awp_root_tp / "qt" / "5.15.16" / "winx64" / "bin",
+            ]
+        )
+    elif version == 251:
+        paths.extend(
+            [
+                awp_root_tp / "IntelCompiler" / "2023.1.0" / "winx64",
+                awp_root_tp / "IntelMKL" / "2023.1.0" / "winx64",
+                awp_root_tp / "hdf5" / "1.12.2" / "winx64",
+                awp_root_tp / "qt" / "5.15.17" / "winx64" / "bin",
             ]
         )
     else:

--- a/src/ansys/mechanical/core/embedding/initializer.py
+++ b/src/ansys/mechanical/core/embedding/initializer.py
@@ -155,17 +155,16 @@ def __windows_store_workaround(version: int) -> None:
     if version == 242 or version == 251:
         # Set the path to the tp directory within the AWP_ROOTXYZ directory
         awp_root_tp = awp_root / "tp"
+        # Set the qt version based on the version of Mechanical
+        qt_version = "5.15.16" if version == 242 else "5.15.17"
         paths.extend(
             [
                 awp_root_tp / "IntelCompiler" / "2023.1.0" / "winx64",
                 awp_root_tp / "IntelMKL" / "2023.1.0" / "winx64",
                 awp_root_tp / "hdf5" / "1.12.2" / "winx64",
+                awp_root_tp / "qt" / qt_version / "winx64" / "bin",
             ]
         )
-        if version == 242:
-            paths.append(awp_root_tp / "qt" / "5.15.16" / "winx64" / "bin")
-        elif version == 251:
-            paths.append(awp_root_tp / "qt" / "5.15.17" / "winx64" / "bin")
     else:
         return
 

--- a/src/ansys/mechanical/core/embedding/initializer.py
+++ b/src/ansys/mechanical/core/embedding/initializer.py
@@ -142,28 +142,33 @@ def __windows_store_workaround(version: int) -> None:
 
     root = os.environ[f"AWP_ROOT{version}"]
     paths = [
-            os.path.join(root, "aisol", "bin", "winx64"),
-            os.path.join(root, "Framework", "bin", "Win64"),
+        os.path.join(root, "aisol", "bin", "winx64"),
+        os.path.join(root, "Framework", "bin", "Win64"),
     ]
     if version == 242:
-        paths.extend([
-            os.path.join(root, "tp", "IntelCompiler", "2023.1.0", "winx64"),
-            os.path.join(root, "tp", "IntelMKL", "2023.1.0", "winx64"),
-            os.path.join(root, "tp", "hdf5", "1.12.2", "winx64"),
-            os.path.join(root, "tp", "qt", "5.15.16", "winx64", "bin"),
-        ])
+        paths.extend(
+            [
+                os.path.join(root, "tp", "IntelCompiler", "2023.1.0", "winx64"),
+                os.path.join(root, "tp", "IntelMKL", "2023.1.0", "winx64"),
+                os.path.join(root, "tp", "hdf5", "1.12.2", "winx64"),
+                os.path.join(root, "tp", "qt", "5.15.16", "winx64", "bin"),
+            ]
+        )
     elif version == 251:
-        paths.extend([
-            os.path.join(root, "tp", "IntelCompiler", "2023.1.0", "winx64"),
-            os.path.join(root, "tp", "IntelMKL", "2023.1.0", "winx64"),
-            os.path.join(root, "tp", "hdf5", "1.12.2", "winx64"),
-            os.path.join(root, "tp", "qt", "5.15.17", "winx64", "bin"),
-        ])
+        paths.extend(
+            [
+                os.path.join(root, "tp", "IntelCompiler", "2023.1.0", "winx64"),
+                os.path.join(root, "tp", "IntelMKL", "2023.1.0", "winx64"),
+                os.path.join(root, "tp", "hdf5", "1.12.2", "winx64"),
+                os.path.join(root, "tp", "qt", "5.15.17", "winx64", "bin"),
+            ]
+        )
     else:
         return
 
     for path in paths:
         os.add_dll_directory(path)
+
 
 def __set_environment(version: int) -> None:
     """Set environment variables to configure embedding."""

--- a/src/ansys/mechanical/core/embedding/initializer.py
+++ b/src/ansys/mechanical/core/embedding/initializer.py
@@ -131,7 +131,6 @@ def __windows_store_workaround(version: int) -> None:
     Note:   This workaround does not include DLL paths used in FSI
             mapping workflows.
     """
-
     # Nothing to do on linux
     if os.name != "nt":
         return


### PR DESCRIPTION
The windows store python uses windows secure DLL loading (via the Win32 API `SetDefaultDllDirectories`), which is not enabled in the python.org distribution. PyMechanical internally changes the process `PATH` environment variable for DLL loading, which does not work if secure DLL loading is used.

A future version of Mechanical may support secure DLL loading, but for the current releases PyMechanical can work around the issue by calling `os.add_dll_directory()`


Fixes  #1136