### PR TITLE
fix: Install `libjbig-dev` for quarto build to succeed in 252 documentation build

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -610,18 +610,6 @@ jobs:
           apt install make lsb-release xvfb poppler-utils -y
           apt install zip pandoc libgl1-mesa-glx mesa-utils texlive-latex-extra latexmk nodejs npm graphviz -y
 
-      # - name: Install libjbig-dev
-      #   run: |
-      #     # libjbig-dev is required for quarto to work on v242 due to this error:
-      #     # pdfinfo: error while loading shared libraries: libjbig.so.2.1: cannot open shared object file: No such file or directory
-
-      #     apt update
-      #     apt install -y libjbig-dev
-
-      #     # Add the /usr/lib/x86_64-linux-gnu/ path to the LD_LIBRARY_PATH (where libjbig-dev .so files are)
-      #     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
-      #     echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
-
       - name: Install gh cli
         run: |
           (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -614,12 +614,9 @@ jobs:
         run: |
           apt update
           apt install -y libjbig-dev
-          echo $LD_LIBRARY_PATH
-          find / -iname *libjbig*.so*
-
-
           # Add the /usr/lib/x86_64-linux-gnu/ path to the LD_LIBRARY_PATH (where libjbig-dev .so files are)
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Install gh cli
         run: |

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -610,6 +610,9 @@ jobs:
           apt install make lsb-release xvfb poppler-utils libjbig-dev -y
           apt install zip pandoc libgl1-mesa-glx mesa-utils texlive-latex-extra latexmk nodejs npm graphviz -y
 
+          # Add the /usr/lib/x86_64-linux-gnu/ path to the LD_LIBRARY_PATH (where libjbig-dev .so files are)
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
+
       - name: Install gh cli
         run: |
           (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -616,7 +616,7 @@ jobs:
           apt install -y libjbig-dev
           echo $LD_LIBRARY_PATH
           find / -iname *libjbig*.so*
-          
+
 
           # Add the /usr/lib/x86_64-linux-gnu/ path to the LD_LIBRARY_PATH (where libjbig-dev .so files are)
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -607,7 +607,7 @@ jobs:
       - name: Install system dependencies
         run: |
           apt update
-          apt install make lsb-release xvfb poppler-utils -y
+          apt install make lsb-release xvfb poppler-utils libjbig-dev -y
           apt install zip pandoc libgl1-mesa-glx mesa-utils texlive-latex-extra latexmk nodejs npm graphviz -y
 
       - name: Install gh cli

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -610,13 +610,17 @@ jobs:
           apt install make lsb-release xvfb poppler-utils -y
           apt install zip pandoc libgl1-mesa-glx mesa-utils texlive-latex-extra latexmk nodejs npm graphviz -y
 
-      - name: Install libjbig-dev
-        run: |
-          apt update
-          apt install -y libjbig-dev
-          # Add the /usr/lib/x86_64-linux-gnu/ path to the LD_LIBRARY_PATH (where libjbig-dev .so files are)
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
+      # - name: Install libjbig-dev
+      #   run: |
+      #     # libjbig-dev is required for quarto to work on v242 due to this error:
+      #     # pdfinfo: error while loading shared libraries: libjbig.so.2.1: cannot open shared object file: No such file or directory
+
+      #     apt update
+      #     apt install -y libjbig-dev
+
+      #     # Add the /usr/lib/x86_64-linux-gnu/ path to the LD_LIBRARY_PATH (where libjbig-dev .so files are)
+      #     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
+      #     echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Install gh cli
         run: |
@@ -684,6 +688,12 @@ jobs:
               exit 1
             fi
           }
+
+          # Install libjbig-dev so quarto doesn't fail its PDF build on v242
+          apt update
+          apt install -y libjbig-dev
+          # Add the /usr/lib/x86_64-linux-gnu/ path to the LD_LIBRARY_PATH (where libjbig-dev .so files are)
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/
 
           # Make the html doc & validate results
           make_doc html

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -607,8 +607,16 @@ jobs:
       - name: Install system dependencies
         run: |
           apt update
-          apt install make lsb-release xvfb poppler-utils libjbig-dev -y
+          apt install make lsb-release xvfb poppler-utils -y
           apt install zip pandoc libgl1-mesa-glx mesa-utils texlive-latex-extra latexmk nodejs npm graphviz -y
+
+      - name: Install libjbig-dev
+        run: |
+          apt update
+          apt install -y libjbig-dev
+          echo $LD_LIBRARY_PATH
+          find / -iname *libjbig*.so*
+          
 
           # Add the /usr/lib/x86_64-linux-gnu/ path to the LD_LIBRARY_PATH (where libjbig-dev .so files are)
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/


### PR DESCRIPTION
apt install libjbig-dev and add the path of the libjbig*.so* files to the LD_LIBRARY_PATH so the quarto cheatsheet build succeeds