### PR TITLE
fix: Add token for release to github ansys/actions v9

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -841,6 +841,7 @@ jobs:
         uses: ansys/actions/release-github@v9
         with:
           library-name: ${{ env.PACKAGE_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   upload_dev_docs:
     name: Upload dev documentation

--- a/doc/changelog.d/1162.fixed.md
+++ b/doc/changelog.d/1162.fixed.md
@@ -1,0 +1,1 @@
+Add token for release to github ansys/actions v9


### PR DESCRIPTION
`ansys/actions/release-github@v9` fails without token