### PR TITLE
fix: Add `self._messages` to BUILDING_GALLERY section in app initialization

### DIFF
--- a/doc/changelog.d/1171.fixed.md
+++ b/doc/changelog.d/1171.fixed.md
@@ -1,0 +1,1 @@
+Add `self._messages` to BUILDING_GALLERY section in app initialization

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -189,6 +189,9 @@ class App:
         # Get the globals dictionary from kwargs
         globals = kwargs.get("globals")
 
+        # Set messages to None before BUILDING_GALLERY check
+        self._messages = None
+
         # If the building gallery flag is set, we need to share the instance
         # This can apply to running the `make -C doc html` command
         if BUILDING_GALLERY:
@@ -201,8 +204,6 @@ class App:
                 if globals:
                     # The next line is covered by test_globals_kwarg_building_gallery
                     instance.update_globals(globals)  # pragma: nocover
-                # Set messages to None
-                self._messages = None
                 # Open the mechdb file if provided
                 if db_file is not None:
                     self.open(db_file)
@@ -242,7 +243,6 @@ class App:
 
         self._updated_scopes: typing.List[typing.Dict[str, typing.Any]] = []
         self._subscribe()
-        self._messages = None
         if globals:
             self.update_globals(globals)
 

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -201,6 +201,8 @@ class App:
                 if globals:
                     # The next line is covered by test_globals_kwarg_building_gallery
                     instance.update_globals(globals)  # pragma: nocover
+                # Set messages to None
+                self._messages = None
                 # Open the mechdb file if provided
                 if db_file is not None:
                     self.open(db_file)

--- a/tests/embedding/test_globals.py
+++ b/tests/embedding/test_globals.py
@@ -104,8 +104,8 @@ def test_enum_importer_exception(rootdir):
 
 @pytest.mark.embedding_scripts
 def test_globals_kwarg_building_gallery(run_subprocess, pytestconfig, rootdir):
-    """Test ViewOrientationType exists when BUILDING_GALLERY is True and globals are updated
-    during the app initialization."""
+    """Test ViewOrientationType exists and messages are printed when BUILDING_GALLERY is True
+    and globals are updated during the app initialization."""
     version = pytestconfig.getoption("ansys_version")
     embedded_py = Path(rootdir) / "tests" / "scripts" / "run_embedded_app.py"
 
@@ -122,3 +122,4 @@ def test_globals_kwarg_building_gallery(run_subprocess, pytestconfig, rootdir):
     stdout = stdout.decode()
 
     assert "ViewOrientationType exists" in stdout
+    assert "The app cannot print messages in the building gallery" not in stdout

--- a/tests/scripts/run_embedded_app.py
+++ b/tests/scripts/run_embedded_app.py
@@ -62,6 +62,12 @@ def test_globals(args):
     app.Graphics.Camera.SetSpecificViewOrientation(ViewOrientationType.Iso)
     print("ViewOrientationType exists")
 
+    # Check that the app can print messages in the building gallery
+    try:
+        app.messages.show()
+    except AssertionError:
+        print("The app cannot print messages in the building gallery")
+
 
 def set_showtriad(args, value):
     """Launch embedded instance of app & set ShowTriad to False."""


### PR DESCRIPTION
Add `self._messages = None` to the BUILDING_GALLERY section of the App initialization so the following AttributeError does not occur when running `make -C doc html`:

```
app.messages.show()

if self.messages is not None:
^^^
AttributeError: 'App' object has no attribute '_messages'. Did you mean: 'messages'?
```