### PR TITLE
fix: Consider multiple `site-packages` folders

### DIFF
--- a/doc/changelog.d/1187.fixed.md
+++ b/doc/changelog.d/1187.fixed.md
@@ -1,0 +1,1 @@
+Consider multiple `site-packages` folders

--- a/src/ansys/mechanical/core/ide_config.py
+++ b/src/ansys/mechanical/core/ide_config.py
@@ -47,7 +47,7 @@ def get_stubs_location():
     site_packages_regex = re.compile(f"{prefix_path}.*site-packages$")
     site_packages_paths = list(filter(site_packages_regex.match, site_packages))
 
-    if len(site_packages_paths) == 1:
+    if len(site_packages_paths) >= 1:
         # Get the stubs location
         stubs_location = Path(site_packages_paths[0]) / "ansys" / "mechanical" / "stubs"
         return stubs_location


### PR DESCRIPTION
@dipinknair encountered multiple `site-packages` locations in a virtual environment (`lib/site-packages/` and `lib64/site-packages`). The `ansys-mechanical-ideconfig` command was raising an exception when there were more than one `site-packages` locations, so this PR considers that possibility