### PR TITLE
chore: Update docker image version for nightly run

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -7,6 +7,7 @@ on:
       revn:
         type: choice
         options:
+        - '261'
         - '252'
         - '251'
         - '242'
@@ -38,7 +39,7 @@ env:
   MAIN_PYTHON_VERSION: '3.11'
   # DEV_REVN & its Docker image are used in scheduled or registry package runs
   STABLE_REVN: '251'
-  DEV_REVN: '252'
+  DEV_REVN: '261'
   LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
   ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -36,7 +36,7 @@ env:
   DOCKER_MECH_CONTAINER_NAME: mechanical
   PACKAGE_NAME: ansys-mechanical-core
   DOCUMENTATION_CNAME: mechanical.docs.pyansys.com
-  MAIN_PYTHON_VERSION: '3.11'
+  MAIN_PYTHON_VERSION: '3.12'
   # DEV_REVN & its Docker image are used in scheduled or registry package runs
   STABLE_REVN: '251'
   DEV_REVN: '261'

--- a/doc/changelog.d/1188.maintenance.md
+++ b/doc/changelog.d/1188.maintenance.md
@@ -1,0 +1,1 @@
+Update docker image version for nightly run


### PR DESCRIPTION
Update to use 26R1 in scheduled ci/cd runs