### PR TITLE
CI: Increase timeout for pytests in CI/CD

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -363,7 +363,7 @@ jobs:
   embedding-tests:
     name: Embedding testing and coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: [smoke-tests, revn-variations, container-stability-check]
     container:
       image: ${{ needs.revn-variations.outputs.test_container }}
@@ -437,7 +437,7 @@ jobs:
   embedding-scripts-tests:
     name: Embedding scripts testing and coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: [smoke-tests, revn-variations]
     container:
       image: ${{ needs.revn-variations.outputs.test_container }}


### PR DESCRIPTION
https://github.com/ansys/pymechanical/actions/runs/15766982543/job/44445322044#step:6:50
Test are now taking more than 10 mins ( New tests might have been added).
Keeping all timeout 15 mins.