### PR TITLE
fix: add more versions to lite host

### DIFF
--- a/doc/changelog.d/1208.fixed.md
+++ b/doc/changelog.d/1208.fixed.md
@@ -1,0 +1,1 @@
+Add more versions to lite host

--- a/src/ansys/mechanical/core/embedding/initializer.py
+++ b/src/ansys/mechanical/core/embedding/initializer.py
@@ -189,7 +189,7 @@ def __set_environment(version: int) -> None:
     # Set an environment variable to use the custom CLR host
     # for embedding.
     # In the future (>251), it would always be used.
-    if version == 251:
+    if version == 251 or version == 252 or version == 261:
         if "PYMECHANICAL_NO_CLR_HOST_LITE" not in os.environ:
             os.environ["ANSYS_MECHANICAL_EMBEDDING_CLR_HOST"] = "1"
 

--- a/tests/embedding/test_app_libraries.py
+++ b/tests/embedding/test_app_libraries.py
@@ -37,7 +37,7 @@ def test_app_library(embedded_app):
     _version = embedded_app.version
 
     # Test with version as input
-    exe = get_mechanical_path(_version)
+    exe = get_mechanical_path(version=embedded_app.version)
     while os.path.basename(exe) != f"v{_version}":
         exe = os.path.dirname(exe)
     exe = exe.replace("\\\\", "\\")


### PR DESCRIPTION
261 to be removed if/when it becomes an opt-out there.

I tested 261 & 252 on linux using github actions - both pass.

I tested 261 & 252 on windows locally, 252 had an issue with and without my changes, 261 was all good

One of the 252 issues was due to an incorrect usage of ansys-tools-path, which I fixed 