### PR TITLE
fix: Add important section to script helpers page for clarification

### DIFF
--- a/doc/changelog.d/1232.fixed.md
+++ b/doc/changelog.d/1232.fixed.md
@@ -1,0 +1,1 @@
+Add important section to script helpers page for clarification

--- a/doc/source/user_guide_scripting/helper_scripts.rst
+++ b/doc/source/user_guide_scripting/helper_scripts.rst
@@ -3,7 +3,13 @@
 Script helpers
 ==============
 
-This section provides a collection of scripting helpers in Ansys Mechanical, with quick links to relevant examples in the Mechanical Scripting Guide.
+This section provides a collection of scripting helpers for Ansys Mechanical. Click the links to see relevant examples in the *Mechanical Scripting Guide*.
+
+.. important::
+
+   The links do not only contain what is described in the bullet points but also additional information.
+   For examples of what is being described in the bullet points, refer to the code sections in the
+   linked content.
 
 
 General setup


### PR DESCRIPTION
Added an important section to the script helpers page to clarify that what the bullet point describes can be found in the code section content of the link

<img width="532" alt="importantblurb" src="https://github.com/user-attachments/assets/80bad206-e55f-40cc-b8bf-341e6face072" />
