### PR TITLE
FEAT: Add option for pep8 aliases in binding

### DIFF
--- a/src/ansys/mechanical/core/embedding/runtime.py
+++ b/src/ansys/mechanical/core/embedding/runtime.py
@@ -45,8 +45,20 @@ def __register_function_codec():
     Ansys.Mechanical.CPython.Codecs.FunctionCodec.Register()
 
 
-def _bind_assembly_for_explicit_interface(assembly_name: str):
-    """Bind the assembly for explicit interface implementation."""
+def _bind_assembly(
+    assembly_name: str, explicit_interface: bool = False, pep8_aliases: bool = False
+) -> None:
+    """Bind the assembly for explicit interface and/or pep8 aliases.
+
+    Parameters
+    ----------
+    assembly_name : str
+        The name of the assembly to bind.
+    explicit_interface : bool, optional
+        If True, allows explicit interface implementation. Default is False.
+    pep8_aliases : bool, optional
+        If True, enables PEP 8 aliases. Default is False.
+    """
     # if pythonnet is not installed, we can't bind the assembly
     try:
         distribution("pythonnet")
@@ -64,7 +76,10 @@ def _bind_assembly_for_explicit_interface(assembly_name: str):
     from Python.Runtime import BindingManager, BindingOptions
 
     binding_options = BindingOptions()
-    binding_options.AllowExplicitInterfaceImplementation = True
+    if explicit_interface:
+        binding_options.AllowExplicitInterfaceImplementation = True
+    if pep8_aliases:
+        binding_options.Pep8Aliases = True
     BindingManager.SetBindingOptions(assembly, binding_options)
 
 
@@ -86,4 +101,4 @@ def initialize(version: int) -> None:
         __register_function_codec()
         Logger.debug("Registered function codec")
 
-    _bind_assembly_for_explicit_interface("Ansys.ACT.WB1")
+    _bind_assembly("Ansys.ACT.WB1", True, True)


### PR DESCRIPTION

This pull request refactors the `_bind_assembly_for_explicit_interface` function to make it more flexible and updates its usage in the `initialize` function. The refactored function now supports additional options for binding assemblies, including enabling PEP 8 aliases.

### Refactoring of `_bind_assembly_for_explicit_interface`:

* Renamed `_bind_assembly_for_explicit_interface` to `_bind_assembly` and added two optional parameters: `explicit_interface` and `pep8_aliases`. This allows the function to handle both explicit interface implementation and PEP 8 aliasing.
* Updated the binding logic to conditionally set `AllowExplicitInterfaceImplementation` and `Pep8Aliases` based on the new parameters.

### Updates to `initialize` function:

* Replaced the call to `_bind_assembly_for_explicit_interface` with `_bind_assembly` and passed `True` for both `explicit_interface` and `pep8_aliases` arguments to enable these features for the "Ansys.ACT.WB1" assembly.

---

Usage:

```
app = App()
app.update_globals(globals())
print(app)

# CamelCase
geometry_import = Model.GeometryImportGroup.AddGeometryImport()
# pep8 formatting
geometry_import = Model.geometry_import_group.add_geometry_import()
```