### PR TITLE
FIX: Update release action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -808,6 +808,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           library-name: ${{ env.PACKAGE_NAME }}
+          only-code: true
 
   release-pypi:
     name: Release project to PyPI


### PR DESCRIPTION
This change will not publish pdf or html files to github release. Currently PyMech doesnt build pdf which is blocking this action from releasing.
