### PR TITLE
CHORE: Increase timeout for tests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -287,7 +287,7 @@ jobs:
   # embedding-rpc-tests:
   #   name: Embedding rpc testing and coverage
   #   runs-on: public-ubuntu-latest-8-cores
-  #   timeout-minutes: 10
+  #   timeout-minutes: 30
   #   needs: [smoke-tests, revn-variations, container-stability-check]
   #   container:
   #     image: ${{ needs.revn-variations.outputs.test_container }}
@@ -362,7 +362,7 @@ jobs:
   embedding-tests:
     name: Embedding testing and coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: [smoke-tests, revn-variations, container-stability-check]
     container:
       image: ${{ needs.revn-variations.outputs.test_container }}
@@ -436,7 +436,7 @@ jobs:
   embedding-scripts-tests:
     name: Embedding scripts testing and coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: [smoke-tests, revn-variations]
     container:
       image: ${{ needs.revn-variations.outputs.test_container }}
@@ -507,7 +507,7 @@ jobs:
   launch-tests:
     name: Launch testing and coverage
     runs-on: public-ubuntu-latest-8-cores
-    timeout-minutes: 15
+    timeout-minutes: 30
     container:
       image: ${{ needs.revn-variations.outputs.test_container }}
       options: --entrypoint /bin/bash

--- a/doc/changelog.d/1288.maintenance.md
+++ b/doc/changelog.d/1288.maintenance.md
@@ -1,0 +1,1 @@
+Increase timeout for tests


### PR DESCRIPTION
This pull request increases the timeout limits for several CI/CD test jobs in the `.github/workflows/ci_cd.yml` file. The main goal is to allow more time for these jobs to complete, likely to address issues with tests timing out.

**CI/CD workflow timeout adjustments:**

* Increased the `timeout-minutes` for the `embedding-tests` job from 15 to 30 minutes.
* Increased the `timeout-minutes` for the `embedding-scripts-tests` job from 15 to 30 minutes.
* Increased the `timeout-minutes` for the `launch-tests` job from 15 to 30 minutes.
* (Commented out) Increased the `timeout-minutes` for the `embedding-rpc-tests` job from 10 to 30 minutes.