### PR TITLE
fix: Notify on failure or cancellation for nightly runs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -839,8 +839,7 @@ jobs:
   notify-on-failure:
     name: Notify on failure
     needs: [get-date, embedding-tests, embedding-scripts-tests, launch-tests, remote-connect, doc-build]
-    if: failure() || cancelled()
-    # if: github.event_name == 'schedule' && (failure() || cancelled())
+    if: github.event_name == 'schedule' && (failure() || cancelled())
     runs-on: ubuntu-latest
     steps:
       - name: Microsoft Teams Notification

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -839,7 +839,8 @@ jobs:
   notify-on-failure:
     name: Notify on failure
     needs: [get-date, embedding-tests, embedding-scripts-tests, launch-tests, remote-connect, doc-build]
-    if: github.event_name == 'schedule' && failure()
+    if: failure() || cancelled()
+    # if: github.event_name == 'schedule' && (failure() || cancelled())
     runs-on: ubuntu-latest
     steps:
       - name: Microsoft Teams Notification


### PR DESCRIPTION
Currently only getting notified for failures, but if a job times out (doc-build step), then it gets cancelled and we aren't notified. This should fix that scenario