### PR TITLE
fix: typo in environment variable

### DIFF
--- a/doc/changelog.d/1615.fixed.md
+++ b/doc/changelog.d/1615.fixed.md
@@ -1,0 +1,1 @@
+Typo in environment variable

--- a/src/ansys/mechanical/core/embedding/shell.py
+++ b/src/ansys/mechanical/core/embedding/shell.py
@@ -74,7 +74,7 @@ def _using_interactive_ipython(warn: bool):
             warnings.warn("""Interactive PyMechanical requires pywin32""")
         return False
 
-    if os.environ.get("PYMECHANICAL_NO_INTERCTIVE_IPYTHON") == "1":
+    if os.environ.get("PYMECHANICAL_NO_INTERACTIVE_IPYTHON") == "1":
         return False
     return True
 


### PR DESCRIPTION
From https://github.com/ansys/pymechanical/pull/1612.