### PR TITLE
fix: add **kwargs to _run_cell_in_thread signature

### DIFF
--- a/doc/changelog.d/1635.fixed.md
+++ b/doc/changelog.d/1635.fixed.md
@@ -1,0 +1,1 @@
+Add **kwargs to _run_cell_in_thread signature

--- a/src/ansys/mechanical/core/embedding/ipython_shell.py
+++ b/src/ansys/mechanical/core/embedding/ipython_shell.py
@@ -155,7 +155,9 @@ def _execution_thread_main():
         _exec_from_queue(shell)
 
 
-def _run_cell_in_thread(self, raw_cell, store_history=False, silent=False, shell_futures=True):
+def _run_cell_in_thread(
+    self, raw_cell, store_history=False, silent=False, shell_futures=True, **kwargs
+):
     CODE_QUEUE.put(raw_cell)
     while not SHUTDOWN_EVENT.is_set():
         try:


### PR DESCRIPTION
Closes #1508 

## Root Cause

PyMechanical's `ipython_shell.py` monkey-patches `InteractiveShell.run_cell` with `_run_cell_in_thread` at **import time** (triggered by `from ansys.mechanical.core import App`). The replacement function's signature:

```python
def _run_cell_in_thread(self, raw_cell, store_history=False, silent=False, shell_futures=True):
```

does not accept `cell_id` or `**kwargs`. When a kernel passes `cell_id=` to `run_cell`, it crashes with `TypeError`.

## Import-Time Trigger Chain

1. `from ansys.mechanical.core import App` → imports `embedding/__init__.py`
2. `embedding/__init__.py` → imports `app.py`
3. `app.py` line 61: `shell.initialize_ipython_shell()` — **runs at module import**
4. `shell.py` checks: `in_ipython()` → True, `HAS_WIN32` → True, env var not set → proceeds
5. `ipython_shell.post_ipython_blocks()` patches `InteractiveShell.run_cell` → `_run_cell_in_thread`

## Why It's Not Reproducible Locally

| Environment | Reproduces? | Reason |
|---|---|---|
| Plain Python / CLI | No | `get_ipython()` returns `None`, patching skipped |
| Jupyter / ipykernel 7.x | No | `_accepts_parameters()` guard checks signature, skips `cell_id` |
| Jupyter / ipykernel 6.12–6.31 | No | `_accepts_cell_id()` guard checks signature, skips `cell_id` |
| Jupyter / ipykernel ≤6.10 | No | `cell_id` not passed at all |
| Spyder / spyder-kernels 3.1.4 | No | Does not override `do_execute`; uses ipykernel's guarded path |

**All tested ipykernel versions that pass `cell_id` also have a signature-introspection guard.**
Spyder-kernels 3.1.4 does not bypass the guard.

### Possible explanations for the customer's crash

1. Customer's package list does not match their actual runtime environment
2. An older `spyder-kernels` version had its own `do_execute` without the guard
3. A Spyder plugin or extension monkey-patches the execution path
4. The current error (May 2026) may be different from the original traceback (Feb 2025)

### Information needed from customer

- Exact `spyder` and `spyder-kernels` versions when the error occurs
- Fresh full traceback from the current error
- Output of `pip list` from the environment where the crash happens

### ipykernel 7.x guard (why Jupyter doesn't crash)

`ipykernel` 7.x introduced `_accepts_parameters()` in `do_execute`:

```python
accepts_params = _accepts_parameters(shell.run_cell, ["cell_id"])
if accepts_params["cell_id"]:
    res = shell.run_cell(code, ..., cell_id=cell_id)
else:
    res = shell.run_cell(code, store_history=store_history, silent=silent)
```

It introspects the patched function's signature and skips `cell_id` if not accepted. **Spyder-kernels does not have this guard.**

## Conditions for the Bug (all must be true)

1. Running inside an IPython kernel (Spyder, Jupyter with older ipykernel, etc.)
2. `pywin32` is installed (`HAS_WIN32 = True`)
3. Kernel calls `run_cell(..., cell_id=...)` without signature introspection
4. `PYMECHANICAL_NO_INTERACTIVE_IPYTHON` env var is **not** set to `"1"`

## Fix

Add `**kwargs` to `_run_cell_in_thread` in `ipython_shell.py`:

```python
def _run_cell_in_thread(self, raw_cell, store_history=False, silent=False, shell_futures=True, **kwargs):
```

## Workaround for Customers

Set the environment variable **before** importing PyMechanical:

```python
import os
os.environ["PYMECHANICAL_NO_INTERACTIVE_IPYTHON"] = "1"

from ansys.mechanical.core import App
```

> **Note:** The variable name is `PYMECHANICAL_NO_INTERACTIVE_IPYTHON` (not `INTERCTIVE`). A typo may explain why the customer reported the workaround didn't work.

## Verification

```python
from ansys.mechanical.core.embedding.ipython_shell import _run_cell_in_thread

# Before fix:
_run_cell_in_thread(None, 'print(1)', cell_id='test')
# TypeError: _run_cell_in_thread() got an unexpected keyword argument 'cell_id'

# After fix:
_run_cell_in_thread(None, 'print(1)', cell_id='test')
# No TypeError (hangs on queue as expected — no shell running)
```
**