### PR TITLE
docs: Getting Started & ecosystem links

### DIFF
--- a/doc/changelog.d/1655.documentation.md
+++ b/doc/changelog.d/1655.documentation.md
@@ -1,0 +1,1 @@
+Getting Started & ecosystem links

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -27,7 +27,7 @@ Install the package
 .. note::
 
    These instructions assume you are familiar
-   with ``pip`` and the command line. If they are new to you, you should read
+   with ``pip`` and the command line. If you are new to them, you should read
    the `Python Packaging User Guide Tutorial on pip <https://packaging.python.org/en/latest/tutorials/installing-packages/>_`
    before proceeding.
 

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -27,7 +27,7 @@ Install the package
 .. note::
    These instructions assume you are familiar
    with ``pip`` and the command line. If they are new to you, you should read
-   the `Python Packaging User Guide Tutorial on pip <https://packaging.python.org/en/latest/tutorials/installing-packages/>`
+   the `Python Packaging User Guide Tutorial on pip <https://packaging.python.org/en/latest/tutorials/installing-packages/>_`
    before proceeding.
 
 The latest ``ansys.mechanical.core`` package supports Python 3.10 through

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -27,7 +27,7 @@ Install the package
 .. note::
    These instructions assume you are familiar
    with ``pip`` and the command line. If they are new to you, you should read
-   the `Python Packaging User Guide Tutorial on pip <python_installing_packages>`
+   the `Python Packaging User Guide Tutorial on pip <https://packaging.python.org/en/latest/tutorials/installing-packages/>`
    before proceeding.
 
 The latest ``ansys.mechanical.core`` package supports Python 3.10 through

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -25,6 +25,7 @@ Install the package
 -------------------
 
 .. note::
+
    These instructions assume you are familiar
    with ``pip`` and the command line. If they are new to you, you should read
    the `Python Packaging User Guide Tutorial on pip <https://packaging.python.org/en/latest/tutorials/installing-packages/>_`

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -24,6 +24,12 @@ a reference:
 Install the package
 -------------------
 
+.. note::
+   These instructions assume you are familiar
+   with ``pip`` and the command line. If they are new to you, you should read
+   the `Python Packaging User Guide Tutorial on pip <python_installing_packages>`
+   before proceeding.
+
 The latest ``ansys.mechanical.core`` package supports Python 3.10 through
 Python 3.14 on Windows, Linux, and Mac.
 

--- a/doc/source/getting_started/troubleshooting.rst
+++ b/doc/source/getting_started/troubleshooting.rst
@@ -118,7 +118,7 @@ Ansys developer ecosystem resources
 Ansys has an extensive developer ecosystem where you can find assistance for a variety of issues.
 
 - `Developer Portal <https://developer.ansys.com/>`_: Blog posts, documentation, and guide
-  - `Developer Forum <https://discuss.ansys.com/>`: Scripting and usage support for PyAnsys and other Ansys developer tools
-- `Ansys Innovation Space <https://innovationspace.ansys.com/>`: Product support forum and training materials
-- `GitHub <https://github.com/ansys/pymechanical>`: Development support, bug reporting, feature requests, and more.
-- `Ansys Learning Hub <https://learninghub.ansys.com/>`: Training, courses and learning plans
+  - `Developer Forum <https://discuss.ansys.com/>`_: Scripting and usage support for PyAnsys and other Ansys developer tools
+- `Ansys Innovation Space <https://innovationspace.ansys.com/>`_: Product support forum and training materials
+- `GitHub <https://github.com/ansys/pymechanical>`_: Development support, bug reporting, feature requests, and more.
+- `Ansys Learning Hub <https://learninghub.ansys.com/>`_: Training, courses and learning plans

--- a/doc/source/getting_started/troubleshooting.rst
+++ b/doc/source/getting_started/troubleshooting.rst
@@ -117,7 +117,7 @@ Ansys developer ecosystem resources
 
 Ansys has an extensive developer ecosystem where you can find assistance for a variety of issues.
 
-- `Developer Portal <https://developer.ansys.com/>`: Blog posts, documentation, and guide
+- `Developer Portal <https://developer.ansys.com/>`_: Blog posts, documentation, and guide
   - `Developer Forum <https://discuss.ansys.com/>`: Scripting and usage support for PyAnsys and other Ansys developer tools
 - `Ansys Innovation Space <https://innovationspace.ansys.com/>`: Product support forum and training materials
 - `GitHub <https://github.com/ansys/pymechanical>`: Development support, bug reporting, feature requests, and more.

--- a/doc/source/getting_started/troubleshooting.rst
+++ b/doc/source/getting_started/troubleshooting.rst
@@ -111,3 +111,14 @@ VPN issues
 Sometimes, Mechanical has issues starting when VPN software is running. For more information,
 see the `Mechanical Users Guide`_
 in the Ansys Help.
+
+Ansys developer ecosystem resources
+-----------------------------------
+
+Ansys has an extensive developer ecosystem where you can find assistance for a variety of issues.
+
+- `Developer Portal <https://developer.ansys.com/>`: Blog posts, documentation, and guide
+  - `Developer Forum <https://discuss.ansys.com/>`: Scripting and usage support for PyAnsys and other Ansys developer tools
+- `Ansys Innovation Space <https://innovationspace.ansys.com/>`: Product support forum and training materials
+- `GitHub <https://github.com/ansys/pymechanical>`: Development support, bug reporting, feature requests, and more.
+- `Ansys Learning Hub <https://learninghub.ansys.com/>`: Training, courses and learning plans


### PR DESCRIPTION
## Summary

I am currently working on reviewing and improving PyAnsys Getting Started sections and this work is part of that. It is reasonable to assume new users of PyMechanical will be familiar with Python and pip but not guaranteed. So I have added a note + link that makes it clearer what those items are for people that don't know when they first get mentioned in the docs.

In addition, I have added a section on the Ansys wider developer ecosystem to the troubleshooting section including a set of links to places where users can expect to find resources that may be of assistance, such as the portal, forum AIS, ALH, etc.

I have not been able to fully build the docs with the changes locally because I do not have Mechanical installed, however, the changes are sufficiently small that a code review should suffice.

## Changes


- added note about pip and python packaging to install instructions
- added dev ecosystem links section to troubleshooting page


## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [x] Tests added or updated
- [x] Documentation updated