### PR TITLE
docs: adding ref to Mech API in card

### DIFF
--- a/doc/changelog.d/1664.documentation.md
+++ b/doc/changelog.d/1664.documentation.md
@@ -1,0 +1,1 @@
+Adding ref to Mech API in card

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -106,6 +106,14 @@ If you are not sure which mode to pick, see :doc:`getting_started/choose_your_mo
 
         :bdg-info:`Classes` :bdg-info:`Methods` :bdg-info:`Error handling`
 
+    .. grid-item-card:: Mechanical scripting API :fa:`code`
+        :padding: 2 2 2 2
+        :link: https://scripting.mechanical.docs.pyansys.com/
+
+        Do you need Mechanical API scripting support? Have a look
+        at its API.
+
+        :bdg-info:`Mechanical API`
 
     .. grid-item-card:: FAQs :fa:`fa-solid fa-circle-question`
         :padding: 2 2 2 2
@@ -134,15 +142,6 @@ If you are not sure which mode to pick, see :doc:`getting_started/choose_your_mo
         or documentation.
 
         :bdg-info:`Test` :bdg-info:`Documentation` :bdg-info:`Issues`
-
-    .. grid-item-card:: Mechanical scripting API :fa:`code`
-        :padding: 2 2 2 2
-        :link: https://scripting.mechanical.docs.pyansys.com/
-
-        Do you need Mechanical API scripting support? Have a look
-        at its API.
-
-        :bdg-info:`Mechanical API`
 
 .. toctree::
    :hidden:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -135,6 +135,14 @@ If you are not sure which mode to pick, see :doc:`getting_started/choose_your_mo
 
         :bdg-info:`Test` :bdg-info:`Documentation` :bdg-info:`Issues`
 
+    .. grid-item-card:: Mechanical scripting API :fa:`code`
+        :padding: 2 2 2 2
+        :link: https://scripting.mechanical.docs.pyansys.com/
+
+        Do you need Mechanical API scripting support? Have a look
+        at its API.
+
+        :bdg-info:`Mechanical API`
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
## Summary
Accessing the Mech scripting API is now pretty difficult. We should expose it via a card.


## Changes
Adding the card with the link

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [x] Documentation updated