### PR TITLE
chore: add workflow to auto-apply skip labels to Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-skip-labels.yml
+++ b/.github/workflows/dependabot-skip-labels.yml
@@ -12,13 +12,17 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   skip-labels:
     name: "Apply skip labels for irrelevant action updates"
     runs-on: ubuntu-latest
     if: startsWith(github.head_ref, 'dependabot/github_actions/')
     permissions:
-      pull-requests: write
+      pull-requests: write   # Required to add labels to the Dependabot PR
 
     steps:
       - name: Apply skip labels based on changed files

--- a/.github/workflows/dependabot-skip-labels.yml
+++ b/.github/workflows/dependabot-skip-labels.yml
@@ -1,0 +1,42 @@
+name: Dependabot skip labels
+
+# Automatically adds 'skip-test' and/or 'skip-doc' labels to Dependabot
+# github-actions PRs when the PR does not touch tests.yml or docs.yml.
+# Dependabot edits a workflow file in-place when it bumps an action used
+# there, so checking the changed files is sufficient — no action allowlist
+# to maintain.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  skip-labels:
+    name: "Apply skip labels for irrelevant action updates"
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'dependabot/github_actions/')
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Apply skip labels based on changed files
+        env:
+          GH_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
+        run: |
+          changed=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '[.files[].path] | join(" ")')
+          echo "Changed files: $changed"
+
+          if ! echo "$changed" | grep -q "tests.yml"; then
+            echo "tests.yml not modified — adding skip-test"
+            gh pr edit "$PR_URL" --add-label "skip-test"
+          fi
+
+          if ! echo "$changed" | grep -q "docs.yml"; then
+            echo "docs.yml not modified — adding skip-doc"
+            gh pr edit "$PR_URL" --add-label "skip-doc"
+          fi

--- a/.github/workflows/dependabot-skip-labels.yml
+++ b/.github/workflows/dependabot-skip-labels.yml
@@ -1,4 +1,4 @@
-name: Dependabot skip labels
+name: Dependabot skip labels (on GH action updates)
 
 # Automatically adds 'skip-test' and/or 'skip-doc' labels to Dependabot
 # github-actions PRs when the PR does not touch tests.yml or docs.yml.

--- a/doc/changelog.d/1672.maintenance.md
+++ b/doc/changelog.d/1672.maintenance.md
@@ -1,0 +1,1 @@
+Add workflow to auto-apply skip labels to Dependabot PRs


### PR DESCRIPTION
## Summary

Apply skip label for test or doc if dependabot PR does not touch any of test.yml or docs.yml


## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [ ] Documentation updated