### PR TITLE
fix: initialize IPython shell only when interactive mode is enabled

### DIFF
--- a/doc/changelog.d/1673.fixed.md
+++ b/doc/changelog.d/1673.fixed.md
@@ -1,0 +1,1 @@
+Initialize IPython shell only when interactive mode is enabled

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -58,8 +58,6 @@ try:
 except ImportError:
     HAS_ANSYS_GRAPHICS = False
 
-shell.initialize_ipython_shell()
-
 
 def _get_default_addin_configuration() -> AddinConfiguration:
     configuration = AddinConfiguration()
@@ -300,6 +298,8 @@ class App:
         feature_flags = kwargs.get("feature_flags", [])
         additional_args = _additional_args(readonly, feature_flags, start_license, self._version)
         self._prepare_interactive_mode()
+        if self.interactive:
+            shell.initialize_ipython_shell()
         runtime.initialize(self._version, pep8_aliases=pep8_alias)
 
         if remove_lock and db_file is not None:


### PR DESCRIPTION
## Summary
Fixes a bug where `shell.initialize_ipython_shell()` was called at module import time and unconditionally, instead of only when an App instance is created in interactive mode.

Fixes #1666 

## Changes

- Moved shell.initialize_ipython_shell() from module level into App.__init__
- Guarded the call with if self.interactive: so it only runs when interactive mode is enabled


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [ ] Documentation updated