### PR TITLE
fix: update IntelCompiler lib path

### DIFF
--- a/doc/changelog.d/1678.fixed.md
+++ b/doc/changelog.d/1678.fixed.md
@@ -1,0 +1,1 @@
+Update IntelCompiler lib path and add CPython path for version 271+

--- a/doc/changelog.d/1678.fixed.md
+++ b/doc/changelog.d/1678.fixed.md
@@ -1,1 +1,1 @@
-Update IntelCompiler lib path and add CPython path for version 271+
+Update IntelCompiler lib path

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,7 +34,7 @@ pyvista.BUILDING_GALLERY = True
 
 
 # Whether or not to build the cheatsheet
-BUILD_CHEATSHEET = "true"
+BUILD_CHEATSHEET = os.environ.get("BUILD_CHEATSHEET") == "true"
 
 # suppress annoying matplotlib bug
 warnings.filterwarnings(

--- a/doc/source/user_guide/remote_session/server-launcher.rst
+++ b/doc/source/user_guide/remote_session/server-launcher.rst
@@ -80,4 +80,4 @@ You can use the ``additional_switches`` keyword argument to specify additional a
 API reference
 ~~~~~~~~~~~~~
 For more information on controlling how Mechanical launches locally, see the
-`launch_mechanical()`_ method.
+:func:`~mechanical.launch_mechanical` method.

--- a/mechanical-env
+++ b/mechanical-env
@@ -169,7 +169,7 @@ if [ "$version" -ge "271" ]; then
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}\
 :${!awp_root}/tp/IntelMKL/2024.2.0/linx64/lib/intel64\
 :${!awp_root}/tp/nss/3.89/lib\
-:${!awp_root}/tp/IntelCompiler/2025.3.2/linx64/lib/intel64\
+:${!awp_root}/tp/IntelCompiler/2025.3.2/linx64/lib\
 :${!awp_root}/tp/qt/5.15.19/linx64/lib\
 :${!awp_root}/tp/openssl/3.5/linx64/lib
 elif [ "$version" = "261" ]; then

--- a/mechanical-env
+++ b/mechanical-env
@@ -169,9 +169,9 @@ if [ "$version" -ge "271" ]; then
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}\
 :${!awp_root}/tp/IntelMKL/2024.2.0/linx64/lib/intel64\
 :${!awp_root}/tp/nss/3.89/lib\
-:${!awp_root}/tp/IntelCompiler/2025.3.2/linx64/lib/intel64\
+:${!awp_root}/tp/IntelCompiler/2025.3.2/linx64/lib\
 :${!awp_root}/tp/qt/5.15.19/linx64/lib\
-:${!awp_root}/tp/openssl/3.5/linx64/lib
+:${!awp_root}/tp/openssl/3.5/linx64/lib\
 elif [ "$version" = "261" ]; then
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}\
 :${!awp_root}/tp/IntelMKL/2024.2.0/linx64/lib/intel64\
@@ -216,6 +216,9 @@ PATH=${MWHOME}/bin-amd64_linux_optimized\
 :${DS_INSTALL_DIR}/CADIntegration/linx64\
 :${!awp_root}/Tools/mono/Linux64/bin\
 :${PATH}
+if [ "$version" -ge "271" ]; then
+    PATH=${!awp_root}/commonfiles/CPython/3_13/linx64/Release/python/bin:${PATH}
+fi
 export PATH
 
 # Adding dummy variable to check if mechanical-env is used

--- a/mechanical-env
+++ b/mechanical-env
@@ -169,7 +169,7 @@ if [ "$version" -ge "271" ]; then
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}\
 :${!awp_root}/tp/IntelMKL/2024.2.0/linx64/lib/intel64\
 :${!awp_root}/tp/nss/3.89/lib\
-:${!awp_root}/tp/IntelCompiler/2025.3.2/linx64/lib/intel64\
+:${!awp_root}/tp/IntelCompiler/2025.3.2/linx64/lib\
 :${!awp_root}/tp/qt/5.15.19/linx64/lib\
 :${!awp_root}/tp/openssl/3.5/linx64/lib
 elif [ "$version" = "261" ]; then
@@ -216,6 +216,9 @@ PATH=${MWHOME}/bin-amd64_linux_optimized\
 :${DS_INSTALL_DIR}/CADIntegration/linx64\
 :${!awp_root}/Tools/mono/Linux64/bin\
 :${PATH}
+if [ "$version" -ge "271" ]; then
+    PATH=${!awp_root}/commonfiles/CPython/3_13/linx64/Release/python/bin:${PATH}
+fi
 export PATH
 
 # Adding dummy variable to check if mechanical-env is used


### PR DESCRIPTION
## Summary
Updates mechanical-env to correctly set library and executable paths for Ansys Mechanical version 271.

## Changes

- Fix LD_LIBRARY_PATH for v271: corrects IntelCompiler/2025.3.2 path from linx64/lib/intel64 to linx64/lib, matching the actual directory layout of the v271 installation


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [ ] Documentation updated