### PR TITLE
fix: disable IPython shell initialization due to pywin bug

### DIFF
--- a/doc/changelog.d/1682.fixed.md
+++ b/doc/changelog.d/1682.fixed.md
@@ -1,0 +1,1 @@
+Disable IPython shell initialization due to pywin bug

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -58,7 +58,8 @@ try:
 except ImportError:
     HAS_ANSYS_GRAPHICS = False
 
-shell.initialize_ipython_shell()
+# TODO: Re-enable when pywin bug is fixed
+# shell.initialize_ipython_shell()
 
 
 def _get_default_addin_configuration() -> AddinConfiguration:


### PR DESCRIPTION
## Summary

Temporarily disable shell.initialize_ipython_shell() at module import time to stop the pywin-related crash when running embedded Mechanical in a Jupyter/IPython environment on Windows.


## Changes

- Comment out shell.initialize_ipython_shell() in app.py with a TODO to re-enable after the bug is resolved


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [ ] Documentation updated