### PR TITLE
docs: add navbar dropdown layout and update theme options

### DIFF
--- a/doc/changelog.d/1688.documentation.md
+++ b/doc/changelog.d/1688.documentation.md
@@ -1,0 +1,1 @@
+Add navbar dropdown layout and update theme options

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -231,6 +231,9 @@ html_theme_options = {
     "collapse_navigation": True,
     "use_edit_page_button": True,
     "header_links_before_dropdown": 5,  # number of links before the dropdown menu
+    "navigation_dropdown": {
+        "layout_file": "navbar.yml",
+    },
     "additional_breadcrumbs": [
         ("PyAnsys", "https://docs.pyansys.com/"),
     ],
@@ -244,7 +247,7 @@ html_theme_options = {
     "whatsnew": {
         "whatsnew_file_name": "../changelog.d/whatsnew.yml",
         "changelog_file_name": "changelog.rst",
-        "sidebar_pages": ["changelog", "index"],
+        "sidebar_pages": ["changelog"],
     },
     "ansys_sphinx_theme_autoapi": {"project": project},
 }

--- a/doc/source/navbar.yml
+++ b/doc/source/navbar.yml
@@ -1,0 +1,55 @@
+- file: index
+  title: "Home"
+
+- file: getting_started/index
+  title: "Getting started"
+  sections:
+    - file: getting_started/installation
+      title: "Installation"
+    - file: getting_started/choose_your_mode
+      title: "Choose your mode"
+    - file: getting_started/running_mechanical
+      title: "Launching PyMechanical"
+    - file: getting_started/docker
+      title: "Docker setup"
+    - file: getting_started/wsl
+      title: "WSL"
+    - file: getting_started/troubleshooting
+      title: "Troubleshooting"
+
+- file: user_guide/index
+  title: "User guide"
+  sections:
+    - file: user_guide/embedding/overview
+      title: "Embedding mode"
+    - file: user_guide/remote_session/overview
+      title: "Remote session mode"
+    - file: user_guide/scripting/overview
+      title: "Scripting fundamentals"
+    - file: user_guide/cli/ansys-mechanical
+      title: "CLI"
+
+- file: examples/index
+  title: "Examples"
+  sections:
+    - file: examples/gallery_examples/index
+      title: "Basic examples: Embedding mode"
+    - file: examples/advanced_examples/index
+      title: "Advanced examples: Embedding mode"
+    - file: examples/remote_examples/index
+      title: "Basic examples: Remote session mode"
+
+- file: api/ansys/mechanical/core/index
+  title: "API reference"
+
+- link: "#"
+  title: "More"
+  sections:
+    - file: contribute
+      title: "Contribute"
+    - file: faq
+      title: "FAQ"
+    - file: kil/index
+      title: "Known issues and limitations"
+    - file: changelog
+      title: "Changelog"


### PR DESCRIPTION
## Summary
Update navbar dropdwon and disable whatsnew on home page. Will be enabled once new ansys-sphinx-theme is released with news and resources.

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [x] Documentation updated