### PR TITLE
chore: drop Python 3.10 support

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,7 +179,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     permissions:
       contents: read
       packages: read  # Required to pull Docker images from GitHub Container Registry
@@ -235,7 +235,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     permissions:
       contents: read
       packages: read  # Required to pull Docker images from GitHub Container Registry
@@ -289,7 +289,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     permissions:
       contents: read
       packages: read  # Required to pull Docker images from GitHub Container Registry

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ PyMechanical provides two distinct modes of interaction:
 Compatibility
 ~~~~~~~~~~~~~
 
-* **Python**: 3.10 – 3.14
+* **Python**: 3.11 – 3.14
 * **Mechanical**: 2024 R2 (v242) and later
 * **Platforms**: Windows, Linux
 

--- a/doc/changelog.d/1693.maintenance.md
+++ b/doc/changelog.d/1693.maintenance.md
@@ -1,0 +1,1 @@
+Drop Python 3.10 support

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -31,7 +31,7 @@ Install the package
    the `Python Packaging User Guide Tutorial on pip <https://packaging.python.org/en/latest/tutorials/installing-packages/>_`
    before proceeding.
 
-The latest ``ansys.mechanical.core`` package supports Python 3.10 through
+The latest ``ansys.mechanical.core`` package supports Python 3.11 through
 Python 3.14 on Windows, Linux, and Mac.
 
 You should consider installing PyMechanical in a virtual environment.
@@ -54,19 +54,19 @@ machine architecture from the `Releases page <https://github.com/ansys/pymechani
 of the PyMechanical repository.
 
 Each wheelhouse archive contains all the Python wheels necessary to install
-PyMechanical from scratch on Windows and Linux for Python 3.10 through Python 3.14. You can install
+PyMechanical from scratch on Windows and Linux for Python 3.11 through Python 3.14. You can install
 a wheelhouse archive on an isolated system with a fresh Python installation or on a
 virtual environment.
 
-For example, on Linux with Python 3.10, unzip the wheelhouse archive and install it with
+For example, on Linux with Python 3.11, unzip the wheelhouse archive and install it with
 this code:
 
 .. code-block:: bash
 
-   unzip ansys-mechanical-core-v0.12.dev0-wheelhouse-Linux-3.10 wheelhouse
+   unzip ansys-mechanical-core-v0.12.dev0-wheelhouse-Linux-3.11 wheelhouse
    pip install ansys-mechanical-core -f wheelhouse --no-index --upgrade --ignore-installed
 
-If you are on Windows with Python 3.10, unzip the ``ansys-mechanical-core-v0.12.dev0-wheelhouse-Windows-3.10``
+If you are on Windows with Python 3.11, unzip the ``ansys-mechanical-core-v0.12.dev0-wheelhouse-Windows-3.11``
 wheelhouse archive to a ``wheelhouse`` directory and then install it using ``pip`` as
 in the preceding example.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ansys-mechanical-core"
 version = "0.12.dev0"
 description = "A python wrapper for Ansys Mechanical"
 readme = "README.rst"
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.11,<4.0"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Synopsys, Inc. and ANSYS, Inc.", email = "pyansys-core@synopsys.com" }]

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -182,7 +182,7 @@ def test_app_print_tree(embedded_app, capsys, assets):
 
 
 # @pytest.mark.embedding
-@pytest.mark.skip(reason="This test hangs on Linux with Python 3.10-3.14")
+@pytest.mark.skip(reason="This test hangs on Linux with Python 3.11-3.14")
 def test_app_poster(embedded_app, printer):
     """The getters of app should be usable after a new().
 


### PR DESCRIPTION
## Summary
Drop python3.10 support

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [x] Documentation updated