### PR TITLE
fix: register private appdata cleanup before atexit embedded app handler

### DIFF
--- a/doc/changelog.d/1697.fixed.md
+++ b/doc/changelog.d/1697.fixed.md
@@ -1,0 +1,1 @@
+Register private appdata cleanup before atexit embedded app handler

--- a/src/ansys/mechanical/core/embedding/app.py
+++ b/src/ansys/mechanical/core/embedding/app.py
@@ -310,6 +310,9 @@ class App:
 
         self._disposed = False
         _INSTANCES.append(self)
+        # Must register before _atexit_embedded_app so cleanup runs after Dispose (atexit is LIFO).
+        if private_appdata:
+            atexit.register(_cleanup_private_appdata, profile)
         if not _INITIALIZED:
             atexit.register(_atexit_embedded_app, _INSTANCES)
             _INITIALIZED = True
@@ -318,10 +321,6 @@ class App:
 
         connect_warnings(self)
         self._poster = None
-
-        # Clean up the private appdata directory on exit if private_appdata is True
-        if private_appdata:
-            atexit.register(_cleanup_private_appdata, profile)
 
         self._updated_scopes: list[dict[str, typing.Any]] = []
         self._subscribe()


### PR DESCRIPTION
## Summary
"atexit handlers run in reverse order of registration. we want the private appdata cleanup to happen after embedding cleanup so that the private appdata exists during cleanup" - credits @koubaa
@wsharp-ansys  Thanks for finding  and reporting the issue  


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [ ] Documentation updated