### PR TITLE
chore: add smoke-test-check job to ci/cd pipeline

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -84,10 +84,27 @@ jobs:
       contents: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
 
+  smoke-test-check:
+    name: Smoke tests check
+    runs-on: ubuntu-latest
+    needs: [smoke-tests]
+    if: always()
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions
+      - uses: ./.github/actions/status-check
+        with:
+          job-name: "Smoke Tests"
+          result: ${{ needs.smoke-tests.result }}
+
   # ── Test suites ────────────────────────────────────────────────────────
   tests:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-test') }}
-    needs: [style, revn-config, smoke-tests]
+    needs: [style, revn-config, smoke-test-check]
     uses: ./.github/workflows/tests.yml
     permissions:
       contents: read
@@ -197,7 +214,7 @@ jobs:
   # ── Package ────────────────────────────────────────────────────────────
   package:
     name: Package library
-    needs: [smoke-tests, test-check, doc-build-check]
+    needs: [smoke-test-check, test-check, doc-build-check]
     runs-on: ubuntu-latest
     permissions:
       attestations: write  # Required to generate package attestations for security

--- a/doc/changelog.d/1698.maintenance.md
+++ b/doc/changelog.d/1698.maintenance.md
@@ -1,0 +1,1 @@
+Add smoke-test-check job to ci/cd pipeline


### PR DESCRIPTION
## Summary
With this change we can change mandatory tests of multiple platform, python versions in main branch rule to single check.

<img width="1317" height="416" alt="image" src="https://github.com/user-attachments/assets/6a31ef9d-c4e4-48ff-94fb-f3cf19ff5dde" />

Above all will be removed and only smoke-test-check will be added. this helps when we are adding or removing python versions so that we dont have to manually add or remove these test from main branch rules.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [ ] Documentation updated