### PR TITLE
feat: add --log-embedding pytest flag and document custom pytest options

### DIFF
--- a/doc/changelog.d/1702.added.md
+++ b/doc/changelog.d/1702.added.md
@@ -1,0 +1,1 @@
+Add --log-embedding pytest flag and document custom pytest options

--- a/doc/source/contribute/developer.rst
+++ b/doc/source/contribute/developer.rst
@@ -189,6 +189,54 @@ See the ``pyproject.toml`` file for a full list of markers (-m) and their descri
 
 To run specific tests based on a keyword, use the ``-k`` argument::
 
+    pytest -k test_license_manager
+
+
+Custom ``pytest`` flags
+-----------------------
+
+PyMechanical adds the following custom command-line options to ``pytest``:
+
+``--ansys-version``
+~~~~~~~~~~~~~~~~~~~
+
+Specify the Ansys Mechanical version to use for testing. When omitted, the version is
+detected automatically from the installed Mechanical path::
+
+    pytest -m embedding --ansys-version=261
+
+``--addin-configuration``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set the addin configuration name passed to :class:`AddinConfiguration`. Defaults to
+``"Mechanical"``::
+
+    pytest -m embedding --addin-configuration=Mechanical
+
+``--log-embedding``
+~~~~~~~~~~~~~~~~~~~
+
+Enable embedding log output to stdout and set the log level. Accepted values are
+``debug``, ``info``, ``warning``, and ``error``. When omitted, the embedding
+logger is not configured by the test suite::
+
+    # Show all messages including debug output
+    pytest -m embedding --ansys-version=261 --log-embedding=debug
+
+    # Show informational messages and above
+    pytest -m embedding --ansys-version=261 --log-embedding=info
+
+    # Combine with -k to target a single test
+    pytest -m embedding -k test_license_manager --ansys-version=261 --log-embedding=debug
+
+``--remote-server-type``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Select the RPC protocol used for remote session tests. Accepted values are ``grpc``
+(default) and ``rpyc``::
+
+    pytest -m remote_session_launch --remote-server-type=grpc
+
 
 Remote testing
 --------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,13 +190,21 @@ def ensure_embedding() -> None:
 
 def start_embedding_app(version, pytestconfig) -> datetime.timedelta:
     """Start the embedded Mechanical application."""
+    import logging
+
     from ansys.mechanical.core import App
+    from ansys.mechanical.core.embedding.logger import Configuration
 
     global EMBEDDED_APP
     ensure_embedding()
     start = datetime.datetime.now()
 
     config = AddinConfiguration(pytestconfig.getoption("addin_configuration"))
+
+    _log_level_str = pytestconfig.getoption("--log-embedding", default=None)
+    if _log_level_str is not None:
+        _log_level = getattr(logging, _log_level_str.upper())
+        Configuration.configure(level=_log_level, to_stdout=True)
 
     EMBEDDED_APP = App(version=int(version))
     assert not EMBEDDED_APP.readonly, (
@@ -577,6 +585,16 @@ def pytest_addoption(parser):
         parser.addoption("--ansys-version", default=str(mechanical_version))
 
     # parser.addoption("--debugging", action="store_true")
+    parser.addoption(
+        "--log-embedding",
+        default=None,
+        choices=["debug", "info", "warning", "error"],
+        help=(
+            "Set the embedding log level written to stdout. "
+            "Choices: debug, info, warning, error. "
+            "When omitted, embedding logging is not configured by the test suite."
+        ),
+    )
     parser.addoption("--addin-configuration", default="Mechanical")
     parser.addoption(
         "--remote-server-type",


### PR DESCRIPTION
## Summary
Adds a --log-embedding pytest CLI option that configures the PyMechanical embedding logger before the embedded App is started, and documents all custom pytest flags in the contributor guide


## Changes

- added --log-embedding option to pytest_addoption in conftest.py with choices debug, info, warning, error (default: omitted / no-op)
- Updated start_embedding_app to call Configuration.configure(level=..., to_stdout=True) when --log-embedding is supplied, before App(...) is initialised
- Added Custom pytest flags section to developer.rst documenting --ansys-version, --addin-configuration, --log-embedding, and --remote-server-type with usage examples


## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [x] Documentation updated