### PR TITLE
fix: include coverage.yml in skip-test label check

### DIFF
--- a/.github/workflows/dependabot-skip-labels.yml
+++ b/.github/workflows/dependabot-skip-labels.yml
@@ -1,10 +1,11 @@
 name: Dependabot skip labels (on GH action updates)
 
 # Automatically adds 'skip-test' and/or 'skip-doc' labels to Dependabot
-# github-actions PRs when the PR does not touch tests.yml or docs.yml.
-# Dependabot edits a workflow file in-place when it bumps an action used
-# there, so checking the changed files is sufficient — no action allowlist
-# to maintain.
+# github-actions PRs when the PR does not touch tests.yml/coverage.yml or
+# docs.yml respectively. Dependabot edits a workflow file in-place when it
+# bumps an action used there, so checking the changed files is sufficient —
+# no action allowlist to maintain. coverage.yml is treated as test-related
+# because it merges test coverage artifacts.
 
 on:
   pull_request:
@@ -35,8 +36,8 @@ jobs:
           changed=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '[.files[].path] | join(" ")')
           echo "Changed files: $changed"
 
-          if ! echo "$changed" | grep -q "tests.yml"; then
-            echo "tests.yml not modified — adding skip-test"
+          if ! echo "$changed" | grep -qE "tests\.yml|coverage\.yml"; then
+            echo "tests.yml and coverage.yml not modified — adding skip-test"
             gh pr edit "$PR_URL" --add-label "skip-test"
           fi
 

--- a/doc/changelog.d/1709.fixed.md
+++ b/doc/changelog.d/1709.fixed.md
@@ -1,0 +1,1 @@
+Include coverage.yml in skip-test label check


### PR DESCRIPTION
## Summary

The `dependabot-skip-labels` workflow was incorrectly adding the `skip-test` label to Dependabot PRs that only modified `coverage.yml`, because the label check only looked for changes to `tests.yml`. Since `coverage.yml` is part of the test pipeline (it merges test coverage artifacts), changes to it should also prevent the `skip-test` label from being applied.

Related to #1706

## Changes

- Updated `dependabot-skip-labels.yml` to also check for `coverage.yml` in the changed files before applying the `skip-test` label


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [ ] Documentation updated