### PR TITLE
feat: add auto-approve and auto-merge steps for pre-commit CI PRs

### DIFF
--- a/.github/workflows/label-pre-commit-pr.yml
+++ b/.github/workflows/label-pre-commit-pr.yml
@@ -18,7 +18,8 @@ jobs:
       github.event.pull_request.user.login == 'pre-commit-ci[bot]' ||
       github.event.pull_request.user.login == 'pyansys-automation'
     permissions:
-      pull-requests: write  # Required to add labels to pull requests
+      pull-requests: write  # Required to add labels and approve pull requests
+      contents: write       # Required to enable auto-merge
     steps:
       - name: Add skip-doc and skip-tests labels
         env:
@@ -26,3 +27,15 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: gh pr edit "${PR_NUMBER}" --add-label "skip-doc" --add-label "skip-test" --repo "${REPO}"
+
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/doc/changelog.d/1718.added.md
+++ b/doc/changelog.d/1718.added.md
@@ -1,0 +1,1 @@
+Add auto-approve and auto-merge steps for pre-commit CI PRs


### PR DESCRIPTION
## Summary

`pre-commit-ci[bot]` PRs for hook updates required manual approval despite being
low-risk, routine changes. This adds auto-approve and auto-merge steps to the
existing labeling workflow so they are handled fully automatically, with branch
protection required checks acting as the safety net.

## Changes

- Added `Approve PR` and `Enable auto-merge` steps to `label-pre-commit-pr.yml`
- Added `contents: write` permission required for auto-merge


## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [ ] Documentation updated