### PR TITLE
chore: bump version to 0.13.dev0 and update pyupgrade to py312-plus

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
     rev: 75992aaa40730136014f34227e0135f63fc951b4  # frozen: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: ['--py310-plus']
+        args: ['--py312-plus']
 
 - repo: https://github.com/crate-ci/typos
   rev: 12ffd4a04b4893ab75db66a59aaad2d996c3e982  # frozen: v1

--- a/doc/changelog.d/1720.maintenance.md
+++ b/doc/changelog.d/1720.maintenance.md
@@ -1,0 +1,1 @@
+Bump version to 0.13.dev0 and update pyupgrade to py312-plus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "ansys-mechanical-core"
-version = "0.12.dev0"
+version = "0.13.dev0"
 description = "A python wrapper for Ansys Mechanical"
 readme = "README.rst"
 requires-python = ">=3.12,<4.0"


### PR DESCRIPTION
## Summary

Bumps the project version to `0.13.dev0` to begin the next development cycle and updates the `pyupgrade` pre-commit hook target to `py312-plus`.

## Changes

- Version bumped to `0.13.dev0` in `pyproject.toml`
- `pyupgrade` hook updated to target Python 3.12+ in `.pre-commit-config.yaml`


## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [ ] Documentation updated