### PR TITLE
fix: update Qt library path to 6.8.8 for version 271 and greater

### DIFF
--- a/doc/changelog.d/1727.fixed.md
+++ b/doc/changelog.d/1727.fixed.md
@@ -1,0 +1,1 @@
+Update Qt library path to 6.8.8 for version 271 and greater

--- a/mechanical-env
+++ b/mechanical-env
@@ -170,7 +170,7 @@ if [ "$version" -ge "271" ]; then
 :${!awp_root}/tp/IntelMKL/2024.2.0/linx64/lib/intel64\
 :${!awp_root}/tp/nss/3.89/lib\
 :${!awp_root}/tp/IntelCompiler/2025.3.2/linx64/lib\
-:${!awp_root}/tp/qt/5.15.19/linx64/lib\
+:${!awp_root}/tp/qt/6.8.8//linx64/lib\
 :${!awp_root}/tp/openssl/3.5/linx64/lib
 elif [ "$version" = "261" ]; then
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}\


### PR DESCRIPTION
## Summary
Updates the Qt library path in `mechanical-env` for Mechanical 271+ from `qt/5.15.19` to `qt/6.8.8`


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [ ] Documentation updated