### PR TITLE
fix: skip deprecation test

### DIFF
--- a/doc/changelog.d/1734.fixed.md
+++ b/doc/changelog.d/1734.fixed.md
@@ -1,0 +1,1 @@
+Skip deprecation test

--- a/mechanical-env
+++ b/mechanical-env
@@ -170,7 +170,7 @@ if [ "$version" -ge "271" ]; then
 :${!awp_root}/tp/IntelMKL/2024.2.0/linx64/lib/intel64\
 :${!awp_root}/tp/nss/3.89/lib\
 :${!awp_root}/tp/IntelCompiler/2025.3.2/linx64/lib\
-:${!awp_root}/tp/qt/5.15.19/linx64/lib\
+:${!awp_root}/tp/qt/6.8.8//linx64/lib\
 :${!awp_root}/tp/openssl/3.5/linx64/lib
 elif [ "$version" = "261" ]; then
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,7 @@ markers = [
     "remote_session_connect: tests that connect to Mechanical and work with gRPC server inside it",
     "minimum_version(num): tests that run if ansys-version is greater than the minimum version provided",
     "version_range(min_revn,max_revn): tests that run if ansys-version is in the range of the minimum and maximum revision numbers inclusive.",
+    "skip_on_linux_version(num): tests that are skipped on Linux for the specified Mechanical revision.",
     "windows_only: tests that run if the testing platform is on Windows",
     "linux_only: tests that run if the testing platform is on Linux",
     "cli: tests for the Command Line Interface",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,6 +151,16 @@ def pytest_collection_modifyitems(config, items):
                 )
                 item.add_marker(skip_versions)
 
+        if "skip_on_linux_version" in item.keywords:
+            revns = [mark.args for mark in item.iter_markers(name="skip_on_linux_version")][0]
+            ansys_version = int(config.getoption("--ansys-version"))
+
+            if "lin" in sys.platform and ansys_version in revns:
+                skip_versions = pytest.mark.skip(
+                    reason=f"Skipped on Linux for ansys-version {ansys_version}."
+                )
+                item.add_marker(skip_versions)
+
         # Skip on platforms other than Windows
         if "windows_only" in item.keywords and sys.platform != "win32":
             skip_except_windows = pytest.mark.skip(reason="Test requires Windows platform.")

--- a/tests/embedding/test_app.py
+++ b/tests/embedding/test_app.py
@@ -51,6 +51,7 @@ def test_app_repr(embedded_app):
 
 
 @pytest.mark.embedding
+@pytest.mark.skip_on_linux_version(271)
 def test_deprecation_warning(embedded_app):
     """Test deprecation warnings."""
     harmonic_acoustic = embedded_app.Model.AddHarmonicAcousticAnalysis()


### PR DESCRIPTION
## Summary
Skip the Linux deprecation test for version 271 till fix the issue with docker image

## Changes

- Skip the deprecation test on Linux for version 271.


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Maintenance / refactor

## Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat: add modal analysis support`)
- [ ] Tests added or updated
- [ ] Documentation updated